### PR TITLE
Issue 29 bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.1 - 2020-03-29
+## Fixed
+- doc issue for mtimecmp
+- mimpid is now part of the default setters list
+
 ## 2.1.0 - 2020-03-29
 ## Fixed
 - Moved machine timer nodes to platform yaml.

--- a/riscv_config/checker.py
+++ b/riscv_config/checker.py
@@ -97,6 +97,7 @@ def add_def_setters(schema_yaml):
     schema_yaml['misa']['default_setter'] = regsetter
     schema_yaml['mstatus']['default_setter'] = regsetter
     schema_yaml['mvendorid']['default_setter'] = regsetter
+    schema_yaml['mimpid']['default_setter'] = regsetter
     schema_yaml['marchid']['default_setter'] = regsetter
     schema_yaml['mhartid']['default_setter'] = regsetter
     schema_yaml['mtvec']['default_setter'] = regsetter

--- a/riscv_config/schemas/schema_platform.yaml
+++ b/riscv_config/schemas/schema_platform.yaml
@@ -89,7 +89,7 @@ mtime:
   default:
     implemented: False
 
-### 
+###
 #mtimecmp
 #--------
 # 


### PR DESCRIPTION
## Fixed
- doc issue for mtimecmp
- mimpid is now part of the default setters list

Close #26 