### PR TITLE
Switch to python-3.6.0 as minimum requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.2.1 - 2020-05-18
+### Changed
+- Changed minimum python version requirement to 3.6.0 which is typically easy to install on all
+  major distributions
+- Updated readme with better installation instructions
+
 ## 2.2.0 - 2020-04-07
 ### Changed
 - Renamed the 'implemented' field  in rv32 and rv64 nodes to 'accessible'.

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -5,58 +5,95 @@ Quickstart
 This doc is meant to serve as a quick-guide to setup RISCV-CONFIG and perform a \
 sample validation of target specifications.
 
-Install Python Dependencies
-===========================
+Install Python
+==============
 
-RISCV-CONFIG requires `pip` and `python` (>=3.7) to be available on your system. If you have issues
-installing either of these directly on your system, we suggest using a virtual environment
-like `pyenv` to make things easy.
+RISCV-CONFIG requires `pip` and `python` (>=3.6) to be available on your system. 
 
-Installing Pyenv [optional]
+Ubuntu
+------
+
+Ubuntu 17.10 and 18.04 by default come with python-3.6.9 which is sufficient for using riscv-config.
+
+If you are are Ubuntu 16.10 and 17.04 you can directly install python3.6 using the Universe
+repository::
+
+  $ sudo apt-get install python3.6
+  $ pip3 install --upgrade pip
+
+If you are using Ubuntu 14.04 or 16.04 you need to get python3.6 from a Personal Package Archive 
+(PPA)::
+
+  $ sudo add-apt-repository ppa:deadsnakes/ppa
+  $ sudo apt-get update
+  $ sudo apt-get install python3.6 -y 
+  $ pip3 install --upgrade pip
+
+You should now have 2 binaries: ``python3`` and ``pip3`` available in your $PATH. 
+You can check the versions as below::
+
+  $ python3 --version
+  Python 3.6.9
+  $ pip3 --version
+  pip 20.1 from <user-path>.local/lib/python3.6/site-packages/pip (python 3.6)
+
+Centos:7
+--------
+The CentOS 7 Linux distribution includes Python 2 by default. However, as of CentOS 7.7, Python 3 
+is available in the base package repository which can be installed using the following commands::
+
+  $ sudo yum update -y
+  $ sudo yum install -y python3
+  $ pip3 install --upgrade pip
+
+For versions prior to 7.7 you can install python3.6 using third-party repositories, such as the 
+IUS repository::
+
+  $ sudo yum update -y
+  $ sudo yum install yum-utils
+  $ sudo yum install https://centos7.iuscommunity.org/ius-release.rpm
+  $ sudo yum install python36u
+  $ pip3 install --upgrade pip
+
+You can check the versions::
+
+  $ python3 --version
+  Python 3.6.8
+  $ pip --version
+  pip 20.1 from <user-path>.local/lib/python3.6/site-packages/pip (python 3.6)
+
+
+Using Virtualenv for Python 
 ---------------------------
 
-If you are working on Ubuntu/Debian systems make sure you have the following libraries installed:
+Many a times folks face issues in installing and managing python versions, which is actually a 
+major issue as many gui elements in Linux use the default python versions. In which case installing
+python3.6 using the above methods might break other software. We thus advise the use of **pyenv** to
+install python3.6.
 
-.. code-block:: bash
+For Ubuntu and CentosOS, please follow the steps here: https://github.com/pyenv/pyenv#basic-github-checkout
 
-  $ sudo apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
-      libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
-      xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
+RHEL users can find more detailed guides for virtual-env here: https://developers.redhat.com/blog/2018/08/13/install-python3-rhel/#create-env
 
-Download and install pyenv:
+Once you have pyenv installed do the following to install python 3.6.0::
 
-.. code-block:: bash
+  $ pyenv install 3.6.0
+  $ pip3 install --upgrade pip
+  $ pyenv shell 3.6.0
+  
+You can check the version in the **same shell**::
 
-  $ curl -L https://raw.githubusercontent.com/yyuu/pyenv-installer/master/bin/pyenv-installer | bash
-
-Add the following lines to your .bashrc:
-
-.. code-block:: bash
-
-  $ export PATH="/home/<username>/.pyenv/bin:$PATH"
-  $ eval "$(pyenv init -)"
-  $ eval "$(pyenv virtualenv-init -)"
-
-Open a new terminal and create a virtual environment using the following
-
-.. code-block:: bash
-
-  $ pyenv install 3.7.0
-  $ pyenv virtualenv 3.7.0 riscv_config_env
-
-
-Now you can activate this virtual environment using the following command:
-
-.. code-block:: bash
-
-  $ pyenv activate riscv_config_env
   $ python --version
+  Python 3.6.0
+  $ pip --version
+  pip 20.1 from <user-path>.local/lib/python3.6/site-packages/pip (python 3.6)
 
-Install via PIP [users]
-=======================
 
-**NOTE**: If you are using `pyenv` as mentioned above, make sure to enable that environment before
-performing the following steps.
+Install RISCV-CONFIG
+====================
+
+.. note:: If you are using a virtual environment make sure to enable that environment before
+  performing the following steps.
 
 .. code-block:: bash
 
@@ -74,9 +111,8 @@ To checkout a specific version of riscv_config:
 
   $ pip install riscv_config--1.x.x
 
-Once you have RISCV_CONFIG installed, executing ``riscv_config --help`` should print the following on the terminal:
-
-.. code-block:: bash
+Once you have RISCV_CONFIG installed, executing ``riscv_config --help`` should print the following 
+output ::
 
     riscv_config [-h] [--version] [--isa_spec YAML] [--platform_spec YAML]
                         [--work_dir DIR] [--verbose]
@@ -96,9 +132,11 @@ Once you have RISCV_CONFIG installed, executing ``riscv_config --help`` should p
 RISCV_CONFIG for Developers
 ===========================
 
-Clone the repository from git and install required dependencies. Note, you will still need
-python-3.7.0 and pip. If you are using `pyenv` as mentioned above, make sure to enable that environment before
-performing the following steps.
+Clone the repository from git and install required dependencies. 
+
+.. note::  you will still need python-3.7.0 and pip. 
+  If you are using `pyenv` as mentioned above, make sure to enable that environment before
+  performing the following steps.
 
 .. code-block:: bash
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -97,19 +97,19 @@ Install RISCV-CONFIG
 
 .. code-block:: bash
 
-  $ pip install riscv_config
+  $ pip3 install riscv_config
 
 To update an already installed version of RISCV-CONFIG to the latest version:
 
 .. code-block:: bash
 
-  $ pip install -U riscv_config
+  $ pip3 install -U riscv_config
 
 To checkout a specific version of riscv_config:
 
 .. code-block:: bash
 
-  $ pip install riscv_config--1.x.x
+  $ pip3 install riscv_config--1.x.x
 
 Once you have RISCV_CONFIG installed, executing ``riscv_config --help`` should print the following 
 output ::
@@ -134,7 +134,7 @@ RISCV_CONFIG for Developers
 
 Clone the repository from git and install required dependencies. 
 
-.. note::  you will still need python-3.7.0 and pip. 
+.. note::  you will still need python (>=3.6.0) and pip. 
   If you are using `pyenv` as mentioned above, make sure to enable that environment before
   performing the following steps.
 

--- a/riscv_config/__init__.py
+++ b/riscv_config/__init__.py
@@ -1,3 +1,3 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
-__version__ = "2.2.0"
+__version__ = "2.2.1"

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(name="riscv_config",
       description="RISC-V Configuration Validator",
       long_description=long_description,
       classifiers=[
-          "Programming Language :: Python :: 3.7",
+          "Programming Language :: Python :: 3.6",
           "License :: OSI Approved :: BSD License",
           "Development Status :: 4 - Beta"
       ],
@@ -36,7 +36,7 @@ setup(name="riscv_config",
       package_dir={'riscv_config': 'riscv_config/'},
       package_data={'riscv_config': ['schemas/*']},
       install_requires=['Cerberus>=1.3.1', 'ruamel.yaml>=0.16.0'],
-      python_requires=">=3.7.0",
+      python_requires=">=3.6.0",
       entry_points={
           "console_scripts": ["riscv-config=riscv_config.main:main"],
       })


### PR DESCRIPTION
- Changed minimum python version requirement to 3.6.0 which is typically easy to install on all
  major distributions
- Updated readme with better installation instructions
