### PR TITLE
bump to 2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 - msb,lsb values of "SD" field in mstatus must be 63 in rv64 mode
 - added checks for reset value of misa to adhere to the extensions enabled in the input yaml
-
+- fixed dead-link in the docs.
 
 ## 2.6.0 - 2021-01-5
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 2.6.0 - 2021-1-5
+## 2.6.1 - 2021-01-13
+### Fixed
+- msb,lsb values of "SD" field in mstatus must be 63 in rv64 mode
+
+
+## 2.6.0 - 2021-01-5
 ### Added
 - Added support for custom csr yaml
 - Added new nodes in isa_schema: pmp_granularity and physical_addr_sz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## 2.6.1 - 2021-01-13
 ### Fixed
 - msb,lsb values of "SD" field in mstatus must be 63 in rv64 mode
+- added checks for reset value of misa to adhere to the extensions enabled in the input yaml
 
 
 ## 2.6.0 - 2021-01-5

--- a/docs/source/yaml-specs.rst
+++ b/docs/source/yaml-specs.rst
@@ -12,7 +12,7 @@ ISA YAML Spec
 **NOTE**:
 
   1. All integer fields accept values as integers or hexadecimals(can be used interchangeably) unless specified otherwise.
-  2. An elaborate example of the full-fledge ISA-YAML file can be found here: `ISA-YAML <https://github.com/riscv/riscv-config/tree/master/examples>`_
+  2. Different examples of the input yamls and the generated checked YAMLs can be found here : `Examples <https://github.com/riscv/riscv-config/tree/master/examples>`_
 
 .. include:: schema_isa.rst
 

--- a/docs/source/yaml-specs.rst
+++ b/docs/source/yaml-specs.rst
@@ -12,7 +12,7 @@ ISA YAML Spec
 **NOTE**:
 
   1. All integer fields accept values as integers or hexadecimals(can be used interchangeably) unless specified otherwise.
-  2. An elaborate example of the full-fledge ISA-YAML file can be found here: `ISA-YAML <https://github.com/riscv/riscv_config/blob/master/examples/template_isa.yaml>`_
+  2. An elaborate example of the full-fledge ISA-YAML file can be found here: `ISA-YAML <https://github.com/riscv/riscv-config/tree/master/examples>`_
 
 .. include:: schema_isa.rst
 

--- a/examples/rv32i_isa.yaml
+++ b/examples/rv32i_isa.yaml
@@ -6,7 +6,7 @@ hart0: &hart0
   physical_addr_sz: 32
   pmp_granularity: 5
   misa:
-   reset-val: 0x40001125
+   reset-val: 0x40143125
    rv32:
      accessible: true
      mxl:

--- a/examples/rv64i_isa.yaml
+++ b/examples/rv64i_isa.yaml
@@ -11,7 +11,7 @@ hart0:
         accessible: true
       reset-val: 0x0
     misa:
-      reset-val: 0x8000000000000100
+      reset-val: 0x8000000000100100
       rv32:
         accessible: false
       rv64:
@@ -23,7 +23,7 @@ hart0:
         extensions:
           implemented: true
           type:
-            ro_constant: 0x100
+            ro_constant: 0x100100
     mvendorid:
       reset-val: 0xdeadbeef
       rv32:
@@ -32,98 +32,6 @@ hart0:
         accessible: true
         type:
           ro_constant: 0xdeadbeef
-    pmpcfg2:
-        rv32:
-            accessible: false
-        rv64:
-            accessible: true
-            pmp8cfg:
-                implemented: true                
-                type:
-                    warl:
-                       dependency_fields: []
-                       legal:
-                         - pmp8cfg[7:0] in [0x00:0xFF]
-                       wr_illegal:
-                         - unchanged 
-            pmp9cfg:
-                implemented: true                
-                type:
-                    warl:
-                       dependency_fields: []
-                       legal:
-                         - pmp9cfg[7:0] in [0x00:0xFF]
-                       wr_illegal:
-                         - unchanged 
-            pmp10cfg:
-                implemented: true
-                lsb: 16                
-                type:
-                    warl:
-                       dependency_fields: []
-                       legal:
-                         - pmp10cfg[7:0] in [0x00:0xFF]
-                       wr_illegal:
-                         - unchanged 
-            pmp11cfg:
-                implemented: true                
-                type:
-                    warl:
-                       dependency_fields: []
-                       legal:
-                         - pmp11cfg[7:0] in [0x00:0xFF]
-                       wr_illegal:
-                         - unchanged 
-            pmp12cfg:
-                implemented: true                
-                type:
-                    warl:
-                       dependency_fields: []
-                       legal:
-                         - pmp12cfg[7:0] in [0x00:0xFF]
-                       wr_illegal:
-                         - unchanged 
-            pmp13cfg:
-                implemented: true                
-                type:
-                    warl:
-                       dependency_fields: []
-                       legal:
-                         - pmp13cfg[7:0] in [0x00:0xFF]
-                       wr_illegal:
-                         - unchanged 
-            pmp14cfg:
-                implemented: true                
-                type:
-                    warl:
-                       dependency_fields: []
-                       legal:
-                         - pmp14cfg[7:0] in [0x00:0xFF]
-                       wr_illegal:
-                         - unchanged 
-            pmp15cfg:
-                implemented: true                
-                type:
-                    warl:
-                       dependency_fields: []
-                       legal:
-                         - pmp15cfg[7:0] in [0x00:0xFF]
-                       wr_illegal:
-                         - unchanged 
-        reset-val: 0x10
-    pmpaddr8:
-        rv32:
-            accessible: false
-        rv64:
-            accessible: true
-            type:
-                warl:
-                    dependency_fields: []
-                    legal:
-                      - pmpaddr8[63:0] in [0x0000000000000000:0xFFFFFFFFFFFFFFFF]
-                    wr_illegal:
-                      - unchanged
-        reset-val: 0x2F
     mtvec:
       reset-val: 0x0000000080000000
       rv64:

--- a/riscv_config/__init__.py
+++ b/riscv_config/__init__.py
@@ -1,3 +1,3 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
-__version__ = "2.6.0"
+__version__ = "2.6.1"

--- a/riscv_config/schemaValidator.py
+++ b/riscv_config/schemaValidator.py
@@ -184,6 +184,20 @@ class schemaValidator(Validator):
             mxl = format(extensions, '#034b')
             if (mxl[33 - s:34 - s] != '1') and (mxl[33 - u:34 - u] != '1'):
                 self._error(field, "neither S nor U is not present(32)")
+                
+    def _check_with_reset_ext(self, field, value):
+        
+        if rv64:
+            mxl = format(extensions, '#066b')
+            reset = format(value, '#066b')
+            if (mxl[40:66] != reset[40:66] ):
+                self._error(field, "reset value does not match with extensions enabled(64)")
+
+        elif rv32 :
+            mxl = format(extensions, '#034b')
+            reset = format(value, '#034b')
+            if (mxl[8:34] != reset[8:34] ):
+                self._error(field, "reset value does not match with extensions enabled(32)")
     
     def _check_with_sn_check(self, field, value):
         s = 18

--- a/riscv_config/schemas/schema_isa.yaml
+++ b/riscv_config/schemas/schema_isa.yaml
@@ -54,7 +54,7 @@ hart_schema:
     # **Constraints**:
     #
     #   - Certain extensions are only valid in certain user-spec version. For, eg. Zifencei is available only in user-spec 2.3 and above.
-    #   - The ISA string must be specified in the manner as specified in the specifications(like subsequent Z extensions must be separated with an '_')
+    #   - The ISA string must be specified as per the convention mentioned in the specifications(like subsequent Z extensions must be separated with an '_')
 
     ISA: { type: string, required: true, check_with: capture_isa_specifics, 
            regex: "^RV(32|64|128)[IE]+[ACDEFGIJLMNPQSTUVX]*(Zicsr|Zifencei|Zihintpause|Zam|Ztso|){,1}(_Zicsr){,1}(_Zifencei){,1}(_Zihintpause){,1}(_Zam){,1}(_Ztso){,1}$" }

--- a/riscv_config/schemas/schema_isa.yaml
+++ b/riscv_config/schemas/schema_isa.yaml
@@ -292,7 +292,7 @@ hart_schema:
         description: {type: string,  default: misa is a read-write register reporting the ISA supported by the hart.}
         address: { type: integer, default: 769, allowed: [769] }
         priv_mode: { type: string, allowed: [M], default: M }
-        reset-val: { type: integer, default: 0, check_with: max_length }
+        reset-val: { type: integer, default: 0, check_with: [max_length, reset_ext] }
         rv32:
           type: dict
           schema:

--- a/riscv_config/schemas/schema_isa.yaml
+++ b/riscv_config/schemas/schema_isa.yaml
@@ -6727,8 +6727,8 @@ hart_schema:
                   default: Read-only bit that summarizes whether either the FS field or
                     XS field signals the presence of some dirty state.
                 shadow: {type: string, default: mstatus.sd, nullable: True}
-                msb: {type: integer, default: 31, allowed: [31]}
-                lsb: {type: integer, default: 31, allowed: [31]}
+                msb: {type: integer, default: 63, allowed: [63]}
+                lsb: {type: integer, default: 63, allowed: [63]}
                 implemented: {type: boolean, default: true}
               default: {implemented: true}
             accessible:


### PR DESCRIPTION
- msb,lsb values of "SD" field in mstatus must be 63 in rv64 mode
- added checks for reset value of misa to adhere to the extensions enabled in the input yaml
- fixed dead-link in the docs.