### PR TITLE
Allow B extension for ISA string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.6.2 - 2021-01-18
+### Fixed
+- Allow B extension in ISA schema
+
 ## 2.6.1 - 2021-01-13
 ### Fixed
 - msb,lsb values of "SD" field in mstatus must be 63 in rv64 mode

--- a/riscv_config/__init__.py
+++ b/riscv_config/__init__.py
@@ -1,3 +1,3 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
-__version__ = "2.6.1"
+__version__ = "2.6.2"

--- a/riscv_config/schemas/schema_isa.yaml
+++ b/riscv_config/schemas/schema_isa.yaml
@@ -57,7 +57,7 @@ hart_schema:
     #   - The ISA string must be specified as per the convention mentioned in the specifications(like subsequent Z extensions must be separated with an '_')
 
     ISA: { type: string, required: true, check_with: capture_isa_specifics, 
-           regex: "^RV(32|64|128)[IE]+[ACDEFGIJLMNPQSTUVX]*(Zicsr|Zifencei|Zihintpause|Zam|Ztso|){,1}(_Zicsr){,1}(_Zifencei){,1}(_Zihintpause){,1}(_Zam){,1}(_Ztso){,1}$" }
+           regex: "^RV(32|64|128)[IE]+[ABCDEFGIJLMNPQSTUVX]*(Zicsr|Zifencei|Zihintpause|Zam|Ztso|){,1}(_Zicsr){,1}(_Zifencei){,1}(_Zihintpause){,1}(_Zam){,1}(_Ztso){,1}$" }
     
     ###
     #User_Spec_Version


### PR DESCRIPTION
The value is already checked in `schemaValidator.py` but not allowed by
the schema.