### PR TITLE
Debug and shadow fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.9.0] - 2021-05-24
+### Fixed
+- fixed issue #58 by adding extra checks for bitmask
+- fixed issue #59 by removing custom cause from platform yaml
+- resolved inconsistencies in the use of "xlen" and "supported_xlen" in schemaValidator
+### Added
+- added extra "shadow_type" fields in the csr schemas. These indicate the nature of shadow
+  (read-only, read-write, etc).
+- added parking_loop node in debug_schema to indicate the address of debug rom. Can be empty in
+  implementations which do not have this feature
+
 ## [2.8.0] - 2021-03-02
 ### Added
 - Added checks for K (sub)extension(s) 

--- a/examples/rv32i_custom.yaml
+++ b/examples/rv32i_custom.yaml
@@ -9,6 +9,7 @@ hart0:
                  type:
                      ro_constant: 0x0
                  shadow:
+                 shadow_type:
                  msb: 31
                  lsb: 0
                  fields:
@@ -27,6 +28,7 @@ hart0:
             ro_constant: 0x1
           description: bit for cache-enable of instruction cache, part of rg_customcontrol
           shadow:
+          shadow_type:
           msb: 0
           lsb: 0
         denable:
@@ -35,6 +37,7 @@ hart0:
             ro_constant: 0x1    
           description: bit for cache-enable of data cache, part of rg_customcontrol
           shadow:
+          shadow_type:
           msb: 1
           lsb: 1
         bpuenable:
@@ -43,6 +46,7 @@ hart0:
             ro_constant: 0x1    
           description: bit for enabling branch predictor unit, part of rg_customcontrol
           shadow:
+          shadow_type:
           msb: 2
           lsb: 2
         arith_excep:
@@ -51,6 +55,7 @@ hart0:
             ro_constant: 0x0    
           description: bit for enabling arithmetic exceptions, part of rg_customcontrol
           shadow:
+          shadow_type:
           msb: 3
           lsb: 3
         fields:

--- a/examples/rv32i_platform.yaml
+++ b/examples/rv32i_platform.yaml
@@ -2,3 +2,7 @@ nmi:
   label: nmi_vector
 reset:
   label: reset_vector
+mtime:
+  implemented: True
+  address: 0x20000
+  neel: myname

--- a/examples/rv64i_isa.yaml
+++ b/examples/rv64i_isa.yaml
@@ -1,63 +1,109 @@
 hart_ids: [0]
 hart0:
-    ISA: RV64IU
-    supported_xlen: [64]
+    custom_exceptions:
+      - cause_val: 25
+        cause_name: halt_ebreak
+        priv_mode: M
+      - cause_val: 26
+        cause_name: halt_trigger
+        priv_mode: M
+      - cause_val: 28
+        cause_name: halt_step
+        priv_mode: M
+      - cause_val: 29
+        cause_name: halt_reset
+        priv_mode: M
+    custom_interrupts:
+      - cause_val: 16
+        cause_name: debug_interrupt
+        on_reset_enable: 1
+        priv_mode : M
+    ISA: RV64IMAFDCSUZicsr_Zifencei
+    User_Spec_Version: '2.3'
+    pmp_granularity: 1
     physical_addr_sz: 32
-    pmp_granularity: 5
-    hpmcounter3:
-      rv32:
-        accessible: false
-      rv64:
-        accessible: true
-      reset-val: 0x0
+    supported_xlen:
+      - 64
     misa:
-      reset-val: 0x8000000000100100
-      rv32:
-        accessible: false
-      rv64:
-        accessible: true
-        mxl:
-          implemented: true
-          type:
-            ro_constant: 0x02
-        extensions:
-          implemented: true
-          type:
-            ro_constant: 0x100100
+        reset-val: 0x800000000014112D
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            mxl:
+                implemented: true
+                type: 
+                    warl:
+                        dependency_fields: []
+                        legal:
+                          - mxl[1:0] in [0x2]
+                        wr_illegal:
+                          - Unchanged
+            extensions:
+                implemented: true
+                type: 
+                    warl:
+                        dependency_fields: []
+                        legal:
+                          - "extensions[25:0] bitmask [0x014112D, 0x0000000]"
+                        wr_illegal:
+                          - "Unchanged"
     mvendorid:
-      reset-val: 0xdeadbeef
-      rv32:
-        accessible: false
-      rv64:
-        accessible: true
-        type:
-          ro_constant: 0xdeadbeef
+        reset-val: 0x0
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            type:
+                ro_constant: 0x0
+    stvec:
+        reset-val: 0x0000000000000000
+        rv64:
+            accessible: true
+            base:
+                implemented: true
+                type:
+                    warl:
+                        dependency_fields: []
+                        legal:
+                          - "base[61:0] bitmask [0x3FFFFFFFFFFFFFFF, 0x0000000000000000]"
+                        wr_illegal:
+                          - "Unchanged"
+            mode:
+                implemented: true
+                type:
+                    warl:
+                        dependency_fields: []
+                        legal:
+                          - 'mode[1:0] in [0x0:0x1]'
+                        wr_illegal:
+                          - Unchanged
+        rv32:
+            accessible: false
     mtvec:
-      reset-val: 0x0000000080000000
-      rv64:
-        accessible: true
-        base:
-          implemented: true
-          type:                             
-            warl: 
-              dependency_fields: [mtvec::mode]
-              legal:
-                - "mode[1:0] in [0] -> base[29:0] in [0x20000000, 0x20004000]"  
-                - "mode[1:0] in [1] -> base[29:6] in [0x000000:0xf00000] base[5:0] in [0x00]"
-              wr_illegal:
-                - "mode[1:0] in [0] -> Unchanged"
-                - "mode[1:0] in [1] wr_val in [0x2000000:0x4000000] -> 0x200000000"
-                - "mode[1:0] in [1] wr_val in [0x4000001:0x1FFFFFFF] -> addr"
-              
-        mode:
-          implemented: true
-          type:                             
-            warl:
-              dependency_fields: []
-              legal: 
-                - "mode[1:0] in [0x0:0x1] # Range of 0 to 1 (inclusive)"
-              wr_illegal:
-                - "Unchanged"
+        reset-val: 0x0000000000000000
+        rv64:
+            accessible: true
+            base:
+                implemented: true
+                type:
+                    warl:
+                        dependency_fields: []
+                        legal:
+                          - "base[61:0] bitmask [0x3FFFFFFFFFFFFFFF, 0x0000000000000000]"
+                        wr_illegal:
+                          - "Unchanged"
+            mode:
+                implemented: true
+                type:
+                    warl:
+                        dependency_fields: []
+                        legal:
+                          - 'mode[1:0] in [0x0:0x1]'
+                        wr_illegal:
+                          - Unchanged
+        rv32:
+            accessible: false
     mstatus:
         rv32:
             accessible: false
@@ -66,51 +112,84 @@ hart0:
             uie:
                 implemented: false
             sie:
-                implemented: false
+                implemented: true
+                type:
+                  wlrl:
+                    - 0:1
             mie:
                 implemented: true
             upie:
                 implemented: false
             spie:
-                implemented: false
+                implemented: true
+                type:
+                  wlrl:
+                    - 0:1
             mpie:
                 implemented: true
             spp:
-                implemented: false
+                implemented: true
+                type:
+                  wlrl:
+                    - 0:1
             mpp:
                 implemented: true
                 type:
                   warl:
                     dependency_fields: []
-                    legal: 
-                      - mpp[1:0] in [0x0, 0x3]
-                    wr_illegal: 
+                    legal:
+                      - mpp[1:0] in [0x0, 0x1, 0x3]
+                    wr_illegal:
                       - Unchanged
             fs:
-                implemented: false
-            xs:
-                implemented: false
-            mprv:
-                implemented: false
+                implemented: true
                 type:
                   warl:
                     dependency_fields: []
-                    legal: 
-                      - mprv[0] in [0x0,0x1]
+                    legal:
+                      - fs[1:0] in [0x0:0x3]
+                    wr_illegal:
+                      - Unchanged
+            xs:
+                implemented: false
+            mprv:
+                implemented: true
+                type:
+                  warl:
+                    dependency_fields: []
+                    legal:
+                      - mprv[0:0] in [0x0:0x1]
                     wr_illegal:
                       - Unchanged
             sum:
-                implemented: false
+                implemented: true
+                type:
+                  wlrl:
+                    - 0:1
             mxr:
-                implemented: false
+                implemented: true
+                type:
+                  wlrl:
+                    - 0:1
             tvm:
-                implemented: false
+                implemented: true
+                type:
+                  wlrl:
+                    - 0:1
             tw:
-                implemented: false
+                implemented: true
+                type:
+                  wlrl:
+                    - 0:1
             tsr:
-                implemented: false
+                implemented: true
+                type:
+                  wlrl:
+                    - 0:1
             sxl:
-                implemented: false
+                implemented: true
+                type:
+                  ro_constant: 2
             uxl:
                 implemented: true
                 type: 
@@ -119,4 +198,482 @@ hart0:
                 implemented: true
                 type:
                     ro_variable: true
-        reset-val: 0x200000000
+        reset-val: 0xA00000000
+    sstatus:
+        rv32:
+          accessible: false
+        rv64:
+          accessible: True
+    marchid:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            type:
+                ro_constant: 5
+        reset-val: 5
+    mimpid:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            type:
+                ro_constant: 0
+        reset-val: 0
+    mhartid:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            type:
+                ro_constant: 0
+        reset-val: 0
+    mip:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            usip:
+                implemented: false
+            ssip:
+                implemented: true
+            msip:
+                implemented: true
+                type:
+                    ro_variable: true
+            utip:
+                implemented: false
+            stip:
+                implemented: true
+            mtip:
+                implemented: true
+                type:
+                    ro_variable: true
+            ueip:
+                implemented: false
+            seip:
+                implemented: true
+            meip:
+                implemented: true
+                type:
+                    ro_variable: true
+            debug_interrupt:
+                implemented: true
+                description: "Debug interrupt"
+                shadow_type:
+                shadow:
+                msb: 16
+                lsb: 16
+        reset-val: 0
+    sip:
+      rv32:
+        accessible: False
+      rv64:
+        accessible: True
+    mie:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            usie:
+                implemented: false
+            ssie:
+                implemented: true
+            msie:
+                implemented: true
+            utie:
+                implemented: false
+            stie:
+                implemented: true
+            mtie:
+                implemented: true
+            ueie:
+                implemented: false
+            seie:
+                implemented: true
+            meie:
+                implemented: true
+        reset-val: 0
+    sie:
+      rv32:
+        accessible: False
+      rv64:
+        accessible: True
+    mscratch:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            type: 
+                warl:
+                    dependency_fields: []
+                    legal:
+                      - mscratch[63:0] in [0x0000000000000000:0xFFFFFFFFFFFFFFFF]
+                    wr_illegal:
+                      - Unchanged
+
+        reset-val: 0
+    sscratch:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            type: 
+                warl:
+                    dependency_fields: []
+                    legal:
+                      - sscratch[63:0] in [0x0000000000000000:0xFFFFFFFFFFFFFFFF]
+                    wr_illegal:
+                      - Unchanged
+
+        reset-val: 0
+    sepc:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            type:
+                warl:
+                    dependency_fields: []
+                    legal:
+                      - "sepc[63:0] bitmask [0xFFFFFFFFFFFFFFFE, 0x0000000000000000]"
+                    wr_illegal:
+                      - "Unchanged"
+        reset-val: 0
+    stval:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            type:
+                warl:
+                    dependency_fields: []
+                    legal:
+                      - stval[63:0] in [0x0000000000000000:0xFFFFFFFFFFFFFFFF]
+                    wr_illegal:
+                      - Unchanged
+        reset-val: 0
+    scause:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            exception_code:
+              implemented: True
+            interrupt:
+              implemented: True
+        reset-val: 0
+    mepc:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            type:
+                warl:
+                    dependency_fields: []
+                    legal:
+                      - "mepc[63:0] bitmask [0xFFFFFFFFFFFFFFFE, 0x0000000000000000]"
+                    wr_illegal:
+                      - "Unchanged"
+        reset-val: 0
+    mtval:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            type:
+                warl:
+                    dependency_fields: []
+                    legal:
+                      - mtval[63:0] in [0x0000000000000000:0xFFFFFFFFFFFFFFFF]
+                    wr_illegal:
+                      - Unchanged
+        reset-val: 0
+    mcause:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+        reset-val: 0
+    mcycle:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            type: 
+                warl:
+                    dependency_fields: []
+                    legal:
+                      - mcycle[63:0] in [0x0000000000000000:0xFFFFFFFFFFFFFFFF]
+                    wr_illegal:
+                      - Unchanged
+        reset-val: 0
+    minstret:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            type: 
+                warl:
+                    dependency_fields: []
+                    legal:
+                      - minstret[63:0] in [0x0000000000000000:0xFFFFFFFFFFFFFFFF]
+                    wr_illegal:
+                      - Unchanged
+        reset-val: 0
+    fflags:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            type:
+                warl:
+                    dependency_fields: []
+                    legal:
+                      - fflags[4:0] in [0x00:0x1F]
+                    wr_illegal:
+                      - Unchanged
+        reset-val: 0
+    frm:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            type:
+                warl:
+                    dependency_fields: []
+                    legal:
+                      - frm[2:0] in [0x0:0x7]
+                    wr_illegal:
+                      - Unchanged
+        reset-val: 0
+    fcsr:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            type:
+                warl:
+                    dependency_fields: []
+                    legal:
+                      - fcsr[7:0] in [0x00:0xFF]
+                    wr_illegal:
+                      - Unchanged
+        reset-val: 0
+    time:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            type:
+                ro_variable: true
+        reset-val: 0
+    mideleg:
+      rv32:
+        accessible: false
+      rv64:
+        accessible: true
+        type:
+          warl:
+            dependency_fields: []
+            legal:
+              - mideleg[63:0] bitmask [0x000000000000F7FF,0x0000000000000000]
+            wr_illegal:
+              - Unchanged
+    medeleg:
+      rv32:
+        accessible: false
+      rv64:
+        accessible: true
+        type:
+          warl:
+            dependency_fields: []
+            legal:
+              - medeleg[63:0] bitmask [0x000000000000F7FF,0x0000000000000000]
+            wr_illegal:
+              - Unchanged
+    pmpcfg0:
+        reset-val: 0
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            pmp0cfg:
+                implemented: true
+                type: 
+                  warl:
+                      dependency_fields: [pmpcfg0::pmp0cfg]
+                      legal:
+                        - "pmp0cfg[7] in [0] -> pmp0cfg[7] in [0x0:0x1] pmp0cfg[6:5] in [0] pmp0cfg[4:3] not in [2] pmp0cfg[2:0] not in [2,6]"
+                      wr_illegal:
+                        - Unchanged
+            pmp1cfg:
+                implemented: true
+                type: 
+                  warl:
+                      dependency_fields: [pmpcfg0::pmp1cfg]
+                      legal:
+                        - "pmp1cfg[7] in [0] -> pmp1cfg[7] in [0x0,0x1] pmp1cfg[6:5] in [0] pmp1cfg[4:3] not in [2] pmp1cfg[2:0] not in [2,6]"
+                      wr_illegal:
+                        - Unchanged
+            pmp2cfg:
+                implemented: true
+                type: 
+                  warl:
+                      dependency_fields: [pmpcfg0::pmp2cfg]
+                      legal:
+                        - "pmp2cfg[7] in [0] -> pmp2cfg[7] in [0x0,0x1] pmp2cfg[6:5] in [0] pmp2cfg[4:3] not in [2] pmp2cfg[2:0] not in [2,6]"
+                      wr_illegal:
+                        - Unchanged
+            pmp3cfg:
+                implemented: true
+                type: 
+                  warl:
+                      dependency_fields: [pmpcfg0::pmp3cfg]
+                      legal:
+                        - "pmp3cfg[7] in [0] -> pmp3cfg[7] in [0x0,0x1] pmp3cfg[6:5] in [0] pmp3cfg[4:3] not in [2] pmp3cfg[2:0] not in [2,6]"
+                      wr_illegal:
+                        - Unchanged
+            pmp4cfg:
+                implemented: false
+            pmp5cfg:
+                implemented: false
+            pmp6cfg:
+                implemented: false
+            pmp7cfg:
+                implemented: false
+    pmpaddr0:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            type: 
+                warl:
+                    dependency_fields: [pmpcfg0::pmp0cfg]
+                    legal:
+                      - "pmp0cfg[7] in [0] -> pmpaddr0[63:0] bitmask [0xFFFFFFFFFFFFFFFE,0x0000000000000000]"
+                    wr_illegal:
+                      - Unchanged
+        reset-val: 0
+    pmpaddr1:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            type: 
+                warl:
+                    dependency_fields: [pmpcfg0::pmp1cfg]
+                    legal:
+                      - "pmp1cfg[7] in [0] -> pmpaddr1[63:0] bitmask [0xFFFFFFFFFFFFFFFE,0x0000000000000000]"
+                    wr_illegal:
+                      - Unchanged
+        reset-val: 0
+    pmpaddr2:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            type: 
+                warl:
+                    dependency_fields: [pmpcfg0::pmp2cfg]
+                    legal:
+                      - "pmp2cfg[7] in [0] -> pmpaddr2[63:0] bitmask [0xFFFFFFFFFFFFFFFE,0x0000000000000000]"
+                    wr_illegal:
+                      - Unchanged
+        reset-val: 0
+    pmpaddr3:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            type: 
+                warl:
+                    dependency_fields: [pmpcfg0::pmp3cfg]
+                    legal:
+                      - "pmp3cfg[7] in [0] -> pmpaddr3[63:0] bitmask [0xFFFFFFFFFFFFFFFE,0x0000000000000000]"
+                    wr_illegal:
+                      - Unchanged
+        reset-val: 0
+    mhpmcounter3:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            type: 
+                warl:
+                    dependency_fields: []
+                    legal:
+                      - "mhpmcounter3[63:0] in [0x0000000000000000:0xFFFFFFFFFFFFFFFF]"
+                    wr_illegal:
+                      - Unchanged
+        reset-val: 0
+    mhpmcounter4:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            type: 
+                warl:
+                    dependency_fields: []
+                    legal:
+                      - "mhpmcounter4[63:0] in [0x0000000000000000:0xFFFFFFFFFFFFFFFF]"
+                    wr_illegal:
+                      - Unchanged
+        reset-val: 0
+    mhpmevent3:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            type: 
+                warl:
+                    dependency_fields: []
+                    legal:
+                      - "mhpmevent3[63:0] in [0x0000000000000000:0x000000000000001C]"
+                    wr_illegal:
+                      - Unchanged
+        reset-val: 0
+    mhpmevent4:
+        rv32:
+            accessible: false
+        rv64:
+            accessible: true
+            type: 
+                warl:
+                    dependency_fields: []
+                    legal:
+                      - "mhpmevent4[63:0] in [0x0000000000000000:0x000000000000001C]"
+                    wr_illegal:
+                      - Unchanged
+        reset-val: 0
+    satp:
+      rv32:
+        accessible: false
+      rv64:
+        accessible: true
+        ppn:
+          type:
+            warl:
+              dependency_fields: []
+              legal:
+                - "ppn[43:0] in [0x00000000000:0xFFFFFFFFFFF]"
+              wr_illegal:
+                - Unchanged
+        asid:
+          type:
+            warl:
+              dependency_fields: []
+              legal:
+                - "asid[15:0] in [0x0000:0x00FF]"
+              wr_illegal:
+                - Unchanged
+        mode:
+          type:
+            warl:
+              dependency_fields: []
+              legal:
+                - "mode[3:0] in [0,8]"
+              wr_illegal:
+                - Unchanged
+      reset-val: 0x0000000000000000
+

--- a/riscv_config/__init__.py
+++ b/riscv_config/__init__.py
@@ -1,3 +1,3 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
-__version__ = '2.8.0'
+__version__ = '2.9.0'

--- a/riscv_config/checker.py
+++ b/riscv_config/checker.py
@@ -715,7 +715,7 @@ def trim(foo):
             temp = foo
             for k in list(
                     set(foo.keys()) -
-                    set(['description', 'msb', 'lsb', 'implemented', 'shadow'])
+                    set(['description', 'msb', 'lsb', 'implemented', 'shadow', 'shadow_type'])
             ):
                 try:
                     temp.pop(k)
@@ -744,7 +744,7 @@ def groupc(test_list):
 def get_fields(node, bitwidth):
     fields = list(
         set(node.keys()) -
-        set(['fields', 'msb', 'lsb', 'accessible', 'shadow', 'type']))
+        set(['fields', 'msb', 'lsb', 'accessible', 'shadow', 'shadow_type','type']))
 
     if not fields:
         return fields
@@ -785,12 +785,12 @@ def check_fields(spec):
             else:
              sub_fields = node['rv32']['fields']
             if not sub_fields :
-             subfields = list(set(['msb', 'lsb', 'accessible', 'shadow', 'fields', 'type']) - set(node['rv32'].keys()) )    
+             subfields = list(set(['msb', 'lsb', 'accessible', 'shadow', 'shadow_type', 'fields', 'type']) - set(node['rv32'].keys()) )    
              if subfields:
                 error.append("The subfield " + "".join(subfields) + " are not present")         
             else:
               for x in sub_fields :
-                subfields = list(set(['msb', 'lsb', 'implemented', 'description', 'shadow', 'type']) - set(node['rv32'][x].keys()) )
+                subfields = list(set(['msb', 'lsb', 'implemented', 'description', 'shadow', 'shadow_type', 'type']) - set(node['rv32'][x].keys()) )
                 if subfields :                   
                    error.append("The subfields " + "".join(subfields) + " are not present in " + str(x))
          if node['rv64']['accessible']:            
@@ -799,12 +799,12 @@ def check_fields(spec):
             else:
              sub_fields = node['rv64']['fields']
             if not sub_fields :
-             subfields = list(set(['msb', 'lsb', 'accessible', 'fields', 'shadow', 'type']) - set(node['rv64'].keys()))
+             subfields = list(set(['msb', 'lsb', 'accessible', 'fields', 'shadow', 'shadow_type', 'type']) - set(node['rv64'].keys()))
              if subfields:
                 error.append("The subfield " + "".join(subfields) + " are not present")
             else:
               for x in sub_fields :
-                subfields = list(set(['msb', 'lsb', 'implemented', 'description', 'shadow', 'type']) - set(node['rv64'][x].keys()) )
+                subfields = list(set(['msb', 'lsb', 'implemented', 'description', 'shadow', 'shadow_type', 'type']) - set(node['rv64'][x].keys()) )
                 if subfields :                   
                    error.append("The subfields " + "".join(subfields) + " are not present in " + str(x))
          if bin(node['address'])[2:][::-1][6:8] != '11' and bin(node['address'])[2:][::-1][8:12] != '0001':
@@ -1295,7 +1295,7 @@ def check_isa_specs(isa_spec,
         #Extract xlen
         xlen = inp_yaml['supported_xlen']
 
-        validator = schemaValidator(schema_yaml, xlen=xlen)
+        validator = schemaValidator(schema_yaml, xlen=xlen, isa_string=inp_yaml['ISA'])
         validator.allow_unknown = False
         validator.purge_readonly = True
         normalized = validator.normalized(inp_yaml, schema_yaml)

--- a/riscv_config/schemaValidator.py
+++ b/riscv_config/schemaValidator.py
@@ -366,12 +366,27 @@ class schemaValidator(Validator):
                 pass
 
         elif value['warl']['dependency_fields'] == [] and pr == 1:
-            self._error(field, "no mode must exist(legal)")
-        elif value['warl']['dependency_fields'] == [] and len(
-                value['warl']['legal']) != 1:
-            self._error(field, "There should be only one legal value")
+            self._error(field, "since dependency_fields is empty no '->' in legal fields")
+        elif value['warl']['dependency_fields'] == [] and len(value['warl']['legal']) != 1:
+            self._error(field, "There should be only one legal string")
         elif value['warl']['dependency_fields'] == [] and pri == 1:
-            self._error(field, "no mode must exist(illlegal)")
+            self._error(field, "since dependency_fields is empty illegal fields must be defined for each")
+        else:
+            for l in value['warl']['legal']:
+                if 'bitmask' in l:
+                    bmask = re.findall(r'\s*\[.*\]\s*bitmask\s*\[(.*?)\]',l)[0]
+                    if ',' not in bmask:
+                        self._error(field, 'Legal string "'+l+'" has wrong bitmask syntax')
+                    if len(bmask.split(','))!=2:
+                        self._error(field, 'Legal string "'+l+'" has wrong bitmkask syntax')
+                    for v in bmask.split(','):
+                        if '0x' not in v:
+                            try:
+                                isinstance(int(v,10),int)
+                            except:
+                                self._error(field, 'Value ' +str(v) + ' in Legal string "'+l+'" is not a valid number')
+
+
 #        elif value['warl']['dependency_fields'] == [] and len(
 #                value['warl']['legal']
 #        ) == 1 and value['warl']['wr_illegal'] != None and "bitmask" in value[

--- a/riscv_config/schemaValidator.py
+++ b/riscv_config/schemaValidator.py
@@ -26,6 +26,12 @@ class schemaValidator(Validator):
             rv64 = False
         super(schemaValidator, self).__init__(*args, **kwargs)
 
+    def _check_with_isa_xlen(self, field, value):
+        global supported_xlen
+        global isa_string
+        if str(max(supported_xlen)) not in isa_string:
+            self._error(field, 'XLEN in ISA and supported_xlen fields do not match')
+
     def _check_with_phy_addr(self, field, value):
         if rv32 and value > 34:
             self._error(field, "Physical address size should not exceed 34 for RV32")

--- a/riscv_config/schemaValidator.py
+++ b/riscv_config/schemaValidator.py
@@ -14,8 +14,8 @@ class schemaValidator(Validator):
         global extensions
         global xlen
         global supported_xlen
-        xlen = max(kwargs.get('xlen'))
         supported_xlen = kwargs.get('xlen')
+        xlen = 0 if len(supported_xlen)==0 else max(supported_xlen)
         global isa_string
         isa_string = kwargs.get('isa_string')
         if 32 in supported_xlen:

--- a/riscv_config/schemaValidator.py
+++ b/riscv_config/schemaValidator.py
@@ -13,14 +13,16 @@ class schemaValidator(Validator):
         global rv64
         global extensions
         global xlen
-        xlen = kwargs.get('xlen')
+        global supported_xlen
+        xlen = max(kwargs.get('xlen'))
+        supported_xlen = kwargs.get('xlen')
         global isa_string
         isa_string = kwargs.get('isa_string')
-        if 32 in xlen:
+        if 32 in supported_xlen:
             rv32 = True
         else:
             rv32 = False
-        if 64 in xlen:
+        if 64 in supported_xlen:
             rv64 = True
         else:
             rv64 = False
@@ -146,9 +148,9 @@ class schemaValidator(Validator):
 
     def _check_with_max_length(self, field, value):
         '''Function to check whether the given value is less than the maximum value that can be stored(2^xlen-1).'''
-        global xlen
+        global supported_xlen
         global extensions
-        maxv = max(xlen)
+        maxv = max(supported_xlen)
         if value > (2**maxv) - 1:
             self._error(field, "Value exceeds max supported length")
 
@@ -401,13 +403,13 @@ class schemaValidator(Validator):
                 self._error(field, " {} not present".format(par[1]))
 
     def _check_with_medeleg_reset(self, field, value):
-        global xlen
-        s = format(value, '#{}b'.format(xlen[0] + 2))
+        global supported_xlen
+        s = format(value, '#{}b'.format(supported_xlen[0] + 2))
         if (s[-11:-10]) != '0' and value >= int("0x400", 16):
             self._error(field, " 11th bit must be hardwired to 0")
 
     def _check_with_sedeleg_reset(self, field, value):
-        global xlen
-        s = format(value, '#{}b'.format(xlen[0] + 2))
+        global supported_xlen
+        s = format(value, '#{}b'.format(supported_xlen[0] + 2))
         if (s[-11:-8]) != '000' and value >= int("400", 16):
             self._error(field, " 11,10,9 bits should be hardwired to 0")

--- a/riscv_config/schemas/schema_debug.yaml
+++ b/riscv_config/schemas/schema_debug.yaml
@@ -56,6 +56,21 @@ hart_schema:
       type: boolean
       required: True
       default: False  
+
+    ###
+    #parking_loop
+    #  **Description**: Integer value indicating the address of the debug parking loop
+    #
+    #  **Examples**:
+    #
+    #  .. code-block: yaml
+    #
+    #     parking_loop: 0x800
+
+    parking_loop:
+      type: integer
+      nullable: True
+      default:
       
     schema_node:
       type: dict

--- a/riscv_config/schemas/schema_debug.yaml
+++ b/riscv_config/schemas/schema_debug.yaml
@@ -123,6 +123,7 @@ hart_schema:
               schema:
                 description: {type: string,  default: Contains the privilege level the hart was operating in when Debug Mode was entered.}
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 1, allowed: [1]}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 implemented: {type: boolean, default: true}
@@ -146,6 +147,7 @@ hart_schema:
               schema:
                 description: { type: string, default: When set and not in Debug Mode the hart will only execute a single instruction;then enter Debug Mode}
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 2, allowed: [2]}
                 lsb: {type: integer, default: 2, allowed: [2]}
                 implemented: {type: boolean, default: true}
@@ -171,6 +173,7 @@ hart_schema:
                   type: string
                   default: When set, there is a Non-Maskable-Interrupt (NMI) pending for the hart.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 3, allowed: [3]}
                 lsb: {type: integer, default: 3, allowed: [3]}
                 implemented: {type: boolean, default: true}
@@ -189,6 +192,7 @@ hart_schema:
                   type: string
                   default: mprv in mstatus.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 4, allowed: [4]}
                 lsb: {type: integer, default: 4, allowed: [4]}
                 implemented: {type: boolean, default: true}
@@ -214,6 +218,7 @@ hart_schema:
                   type: string
                   default: Extends the prv field with the virtualization mode WARL 0 the hart was operating in when Debug Mode was entered 
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 5, allowed: [5]}
                 lsb: {type: integer, default: 5, allowed: [5]}
                 implemented: {type: boolean, default: true}
@@ -241,6 +246,7 @@ hart_schema:
                   type: string
                   default: Explains why Debug Mode was entered
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 8, allowed: [8]}
                 lsb: {type: integer, default: 6, allowed: [6]}
                 implemented: {type: boolean, default: true}
@@ -260,6 +266,7 @@ hart_schema:
                   type: string
                   default: Don’t increment any hart-local timers while in Debug Mode.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 9, allowed: [9]}
                 lsb: {type: integer, default: 9, allowed: [9]}
                 implemented: {type: boolean, default: true}
@@ -284,6 +291,7 @@ hart_schema:
                   type: string
                   default: Don’t increment any hart-local counters while in Debug Mode
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 10, allowed: [10]}
                 lsb: {type: integer, default: 10, allowed: [10]}
                 implemented: {type: boolean, default: true}
@@ -308,6 +316,7 @@ hart_schema:
                   type: string
                   default: Interrupts (including NMI) are enabled during single stepping.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 11, allowed: [11]}
                 lsb: {type: integer, default: 11, allowed: [11]}
                 implemented: {type: boolean, default: true}
@@ -332,6 +341,7 @@ hart_schema:
                   type: string
                   default: ebreak instructions in U-mode enter Debug Mode.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 12, allowed: [12]}
                 lsb: {type: integer, default: 12, allowed: [12]}
                 implemented: {type: boolean, default: true}
@@ -353,6 +363,7 @@ hart_schema:
                   type: string
                   default: ebreak instructions in S-mode enter Debug Mode.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 13, allowed: [13]}
                 lsb: {type: integer, default: 13, allowed: [13]}
                 implemented: {type: boolean, default: true}
@@ -374,6 +385,7 @@ hart_schema:
                   type: string
                   default: ebreak instructions in M-mode enter Debug Mode.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 15, allowed: [15]}
                 lsb: {type: integer, default: 15, allowed: [15]}
                 implemented: {type: boolean, default: true}
@@ -399,6 +411,7 @@ hart_schema:
                   type: string
                   default: ebreak instructions in VU-mode enter Debug Mode.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 16, allowed: [16]}
                 lsb: {type: integer, default: 16, allowed: [16]}
                 implemented: {type: boolean, default: true}
@@ -420,6 +433,7 @@ hart_schema:
                   type: string
                   default: ebreak instructions in VS-mode enter Debug Mode.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 17, allowed: [17]}
                 lsb: {type: integer, default: 17, allowed: [17]}
                 implemented: {type: boolean, default: true}
@@ -441,6 +455,7 @@ hart_schema:
                   type: string
                   default: Debug support exists as it is described in this document.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 31, allowed: [31]}
                 lsb: {type: integer, default: 28, allowed: [28]}
                 implemented: {type: boolean, default: true}
@@ -464,6 +479,7 @@ hart_schema:
               schema:
                 description: {type: string,  default: Contains the privilege level the hart was operating in when Debug Mode was entered.}
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 1, allowed: [1]}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 implemented: {type: boolean, default: true}
@@ -487,6 +503,7 @@ hart_schema:
               schema:
                 description: { type: string, default: When set and not in Debug Mode the hart will only execute a single instruction;then enter Debug Mode}
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 2, allowed: [2]}
                 lsb: {type: integer, default: 2, allowed: [2]}
                 implemented: {type: boolean, default: true}
@@ -512,6 +529,7 @@ hart_schema:
                   type: string
                   default: When set, there is a Non-Maskable-Interrupt (NMI) pending for the hart.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 3, allowed: [3]}
                 lsb: {type: integer, default: 3, allowed: [3]}
                 implemented: {type: boolean, default: true}
@@ -530,6 +548,7 @@ hart_schema:
                   type: string
                   default: mprv in mstatus.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 4, allowed: [4]}
                 lsb: {type: integer, default: 4, allowed: [4]}
                 implemented: {type: boolean, default: true}
@@ -555,6 +574,7 @@ hart_schema:
                   type: string
                   default: Extends the prv field with the virtualization mode WARL 0 the hart was operating in when Debug Mode was entered 
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 5, allowed: [5]}
                 lsb: {type: integer, default: 5, allowed: [5]}
                 implemented: {type: boolean, default: true}
@@ -582,6 +602,7 @@ hart_schema:
                   type: string
                   default: Explains why Debug Mode was entered
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 8, allowed: [8]}
                 lsb: {type: integer, default: 6, allowed: [6]}
                 implemented: {type: boolean, default: true}
@@ -599,6 +620,7 @@ hart_schema:
                   type: string
                   default: Don’t increment any hart-local timers while in Debug Mode.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 9, allowed: [9]}
                 lsb: {type: integer, default: 9, allowed: [9]}
                 implemented: {type: boolean, default: true}
@@ -623,6 +645,7 @@ hart_schema:
                   type: string
                   default: Don’t increment any hart-local counters while in Debug Mode
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 10, allowed: [10]}
                 lsb: {type: integer, default: 10, allowed: [10]}
                 implemented: {type: boolean, default: true}
@@ -647,6 +670,7 @@ hart_schema:
                   type: string
                   default: Interrupts (including NMI) are enabled during single stepping.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 11, allowed: [11]}
                 lsb: {type: integer, default: 11, allowed: [11]}
                 implemented: {type: boolean, default: true}
@@ -671,6 +695,7 @@ hart_schema:
                   type: string
                   default: ebreak instructions in U-mode enter Debug Mode.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 12, allowed: [12]}
                 lsb: {type: integer, default: 12, allowed: [12]}
                 implemented: {type: boolean, default: true}
@@ -692,6 +717,7 @@ hart_schema:
                   type: string
                   default: ebreak instructions in S-mode enter Debug Mode.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 13, allowed: [13]}
                 lsb: {type: integer, default: 13, allowed: [13]}
                 implemented: {type: boolean, default: true}
@@ -713,6 +739,7 @@ hart_schema:
                   type: string
                   default: ebreak instructions in M-mode enter Debug Mode.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 15, allowed: [15]}
                 lsb: {type: integer, default: 15, allowed: [15]}
                 implemented: {type: boolean, default: true}
@@ -738,6 +765,7 @@ hart_schema:
                   type: string
                   default: ebreak instructions in VU-mode enter Debug Mode.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 16, allowed: [16]}
                 lsb: {type: integer, default: 16, allowed: [16]}
                 implemented: {type: boolean, default: true}
@@ -759,6 +787,7 @@ hart_schema:
                   type: string
                   default: ebreak instructions in VS-mode enter Debug Mode.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 17, allowed: [17]}
                 lsb: {type: integer, default: 17, allowed: [17]}
                 implemented: {type: boolean, default: true}
@@ -780,6 +809,7 @@ hart_schema:
                   type: string
                   default: Debug support exists as it is described in this document.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 31, allowed: [31]}
                 lsb: {type: integer, default: 28, allowed: [28]}
                 implemented: {type: boolean, default: true}
@@ -812,6 +842,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -838,6 +869,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -877,6 +909,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -903,6 +936,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -941,6 +975,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -965,6 +1000,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:

--- a/riscv_config/schemas/schema_isa.yaml
+++ b/riscv_config/schemas/schema_isa.yaml
@@ -210,6 +210,7 @@ hart_schema:
         schema:
           cause_val: {type: integer, min: 24, max: 63, forbidden: [16,17,18,19,20,21,22,23,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47]}
           cause_name: {type: string}
+          priv_mode: {type: string, default: 'M', allowed: ['M','S','U']}
         nullable: True
       nullable: True
       default:
@@ -241,6 +242,8 @@ hart_schema:
         schema:
           cause_val: {type: integer, min: 16}
           cause_name: {type: string}
+          on_reset_enable: {type: integer, min: 0, max: 1, default: 0}
+          priv_mode: {type: string, default: 'M', allowed: ['M','S','U']}
         nullable: True
       nullable: True
       default:
@@ -283,6 +286,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -303,6 +307,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -328,6 +333,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -365,6 +371,7 @@ hart_schema:
               schema:
                 description: {type: string,  default: Encodes the native base integer ISA width.}
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: { type: integer, default: 31, allowed: [31] }
                 lsb: { type: integer, default: 30, allowed: [30] }
                 implemented: { type: boolean, default: false }
@@ -384,6 +391,7 @@ hart_schema:
                   default: Encodes the presence of the standard extensions, with a single
                     bit per letter of the alphabet.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 25, allowed: [25]}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 implemented: {type: boolean, default: false}
@@ -411,6 +419,7 @@ hart_schema:
                   type: string
                   default: Encodes the native base integer ISA width.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 63, allowed: [63]}
                 lsb: {type: integer, default: 62, allowed: [62]}
                 implemented: {type: boolean, default: true}
@@ -430,6 +439,7 @@ hart_schema:
                   default: Encodes the presence of the standard extensions, with a single
                     bit per letter of the alphabet.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 25, allowed: [25]}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 implemented: {type: boolean, default: true}
@@ -468,6 +478,7 @@ hart_schema:
               schema:
                 description: {type: string,  default: Stores the state of the user mode interrupts.}
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 0, allowed: [0]}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 implemented: {type: boolean, default: true}
@@ -486,6 +497,7 @@ hart_schema:
               schema:
                 description: { type: string, default: Stores the state of the supervisor mode interrupts.}
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 1, allowed: [1]}
                 lsb: {type: integer, default: 1, allowed: [1]}
                 implemented: {type: boolean, default: true}
@@ -506,6 +518,7 @@ hart_schema:
                   type: string
                   default: Stores the state of the machine mode interrupts.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 3, allowed: [3]}
                 lsb: {type: integer, default: 3, allowed: [3]}
                 implemented: {type: boolean, default: true}
@@ -522,6 +535,7 @@ hart_schema:
                   type: string
                   default: Stores the state of the user mode interrupts prior to the trap.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 4, allowed: [4]}
                 lsb: {type: integer, default: 4, allowed: [4]}
                 implemented: {type: boolean, default: true}
@@ -543,6 +557,7 @@ hart_schema:
                   default: Stores the state of the supervisor mode interrupts prior to
                     the trap.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 5, allowed: [5]}
                 lsb: {type: integer, default: 5, allowed: [5]}
                 implemented: {type: boolean, default: true}
@@ -564,6 +579,7 @@ hart_schema:
                   default: Stores the state of the machine mode interrupts prior to the
                     trap.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 7, allowed: [7]}
                 lsb: {type: integer, default: 7, allowed: [7]}
                 implemented: {type: boolean, default: true}
@@ -580,6 +596,7 @@ hart_schema:
                   type: string
                   default: Stores the previous priority mode for supervisor.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 8, allowed: [8]}
                 lsb: {type: integer, default: 8, allowed: [8]}
                 implemented: {type: boolean, default: true}
@@ -600,6 +617,7 @@ hart_schema:
                   type: string
                   default: Stores the previous priority mode for machine.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 12, allowed: [12]}
                 lsb: {type: integer, default: 11, allowed: [11]}
                 implemented: {type: boolean, default: true}
@@ -620,6 +638,7 @@ hart_schema:
                   default: Encodes the status of the floating-point unit, including the
                     CSR fcsr and floating-point data registers.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 14, allowed: [14]}
                 lsb: {type: integer, default: 13, allowed: [13]}
                 implemented: {type: boolean, default: true}
@@ -639,6 +658,7 @@ hart_schema:
                   default: Encodes the status of additional user-mode extensions and associated
                     state.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 16, allowed: [16]}
                 lsb: {type: integer, default: 15, allowed: [15]}
                 implemented: {type: boolean, default: true}
@@ -659,6 +679,7 @@ hart_schema:
                   default: Modifies the privilege level at which loads and stores execute
                     in all privilege modes.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 17, allowed: [17]}
                 lsb: {type: integer, default: 17, allowed: [17]}
                 implemented: {type: boolean, default: true}
@@ -680,6 +701,7 @@ hart_schema:
                   default: Modifies the privilege with which S-mode loads and stores access
                     virtual memory.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 18, allowed: [18]}
                 lsb: {type: integer, default: 18, allowed: [18]}
                 implemented: {type: boolean, default: true}
@@ -700,6 +722,7 @@ hart_schema:
                   type: string
                   default: Modifies the privilege with which loads access virtual memory.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 19, allowed: [19]}
                 lsb: {type: integer, default: 19, allowed: [19]}
                 implemented: {type: boolean, default: true}
@@ -721,6 +744,7 @@ hart_schema:
                   default: Supports intercepting supervisor virtual-memory management
                     operations.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 20, allowed: [20]}
                 lsb: {type: integer, default: 20, allowed: [20]}
                 implemented: {type: boolean, default: true}
@@ -741,6 +765,7 @@ hart_schema:
                   type: string
                   default: Supports intercepting the WFI instruction.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 21, allowed: [21]}
                 lsb: {type: integer, default: 21, allowed: [21]}
                 implemented: {type: boolean, default: true}
@@ -761,6 +786,7 @@ hart_schema:
                   type: string
                   default: Supports intercepting the supervisor exception return instruction.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 22, allowed: [22]}
                 lsb: {type: integer, default: 22, allowed: [22]}
                 implemented: {type: boolean, default: true}
@@ -782,6 +808,7 @@ hart_schema:
                   default: Read-only bit that summarizes whether either the FS field or
                     XS field signals the presence of some dirty state.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 31, allowed: [31]}
                 lsb: {type: integer, default: 31, allowed: [31]}
                 implemented: {type: boolean, default: true}
@@ -803,6 +830,7 @@ hart_schema:
               schema:
                 description: {type: string,  default: Stores the state of the user mode interrupts.}
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 0, allowed: [0]}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 implemented: {type: boolean, default: true}
@@ -821,6 +849,7 @@ hart_schema:
               schema:
                 description: { type: string, default: Stores the state of the supervisor mode interrupts.}
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 1, allowed: [1]}
                 lsb: {type: integer, default: 1, allowed: [1]}
                 implemented: {type: boolean, default: true}
@@ -841,6 +870,7 @@ hart_schema:
                   type: string
                   default: Stores the state of the machine mode interrupts.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 3, allowed: [3]}
                 lsb: {type: integer, default: 3, allowed: [3]}
                 implemented: {type: boolean, default: true}
@@ -857,6 +887,7 @@ hart_schema:
                   type: string
                   default: Stores the state of the user mode interrupts prior to the trap.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 4, allowed: [4]}
                 lsb: {type: integer, default: 4, allowed: [4]}
                 implemented: {type: boolean, default: true}
@@ -878,6 +909,7 @@ hart_schema:
                   default: Stores the state of the supervisor mode interrupts prior to
                     the trap.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 5, allowed: [5]}
                 lsb: {type: integer, default: 5, allowed: [5]}
                 implemented: {type: boolean, default: true}
@@ -899,6 +931,7 @@ hart_schema:
                   default: Stores the state of the machine mode interrupts prior to the
                     trap.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 7, allowed: [7]}
                 lsb: {type: integer, default: 7, allowed: [7]}
                 implemented: {type: boolean, default: true}
@@ -915,6 +948,7 @@ hart_schema:
                   type: string
                   default: Stores the previous priority mode for supervisor.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 8, allowed: [8]}
                 lsb: {type: integer, default: 8, allowed: [8]}
                 implemented: {type: boolean, default: true}
@@ -935,6 +969,7 @@ hart_schema:
                   type: string
                   default: Stores the previous priority mode for machine.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 12, allowed: [12]}
                 lsb: {type: integer, default: 11, allowed: [11]}
                 implemented: {type: boolean, default: true}
@@ -955,6 +990,7 @@ hart_schema:
                   default: Encodes the status of the floating-point unit, including the
                     CSR fcsr and floating-point data registers.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 14, allowed: [14]}
                 lsb: {type: integer, default: 13, allowed: [13]}
                 implemented: {type: boolean, default: true}
@@ -975,6 +1011,7 @@ hart_schema:
                   default: Encodes the status of additional user-mode extensions and associated
                     state.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 16, allowed: [16]}
                 lsb: {type: integer, default: 15, allowed: [15]}
                 implemented: {type: boolean, default: true}
@@ -996,6 +1033,7 @@ hart_schema:
                   default: Modifies the privilege level at which loads and stores execute
                     in all privilege modes.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 17, allowed: [17]}
                 lsb: {type: integer, default: 17, allowed: [17]}
                 implemented: {type: boolean, default: true}
@@ -1017,6 +1055,7 @@ hart_schema:
                   default: Modifies the privilege with which S-mode loads and stores access
                     virtual memory.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 18, allowed: [18]}
                 lsb: {type: integer, default: 18, allowed: [18]}
                 implemented: {type: boolean, default: true}
@@ -1037,6 +1076,7 @@ hart_schema:
                   type: string
                   default: Modifies the privilege with which loads access virtual memory.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 19, allowed: [19]}
                 lsb: {type: integer, default: 19, allowed: [19]}
                 implemented: {type: boolean, default: true}
@@ -1058,6 +1098,7 @@ hart_schema:
                   default: Supports intercepting supervisor virtual-memory management
                     operations.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 20, allowed: [20]}
                 lsb: {type: integer, default: 20, allowed: [20]}
                 implemented: {type: boolean, default: true}
@@ -1078,6 +1119,7 @@ hart_schema:
                   type: string
                   default: Supports intercepting the WFI instruction.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 21, allowed: [21]}
                 lsb: {type: integer, default: 21, allowed: [21]}
                 implemented: {type: boolean, default: true}
@@ -1098,6 +1140,7 @@ hart_schema:
                   type: string
                   default: Supports intercepting the supervisor exception return instruction.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 22, allowed: [22]}
                 lsb: {type: integer, default: 22, allowed: [22]}
                 implemented: {type: boolean, default: true}
@@ -1118,6 +1161,7 @@ hart_schema:
                   type: string
                   default: Controls the value of xlen for Supervisor mode.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 35, allowed: [35]}
                 lsb: {type: integer, default: 34, allowed: [34]}
                 implemented: {type: boolean, default: true}
@@ -1136,6 +1180,7 @@ hart_schema:
               schema:
                 description: {type: string, default: Controls the xlen for User mode.}
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 33, allowed: [33]}
                 lsb: {type: integer, default: 32, allowed: [32]}
                 implemented: {type: boolean, default: true}
@@ -1157,6 +1202,7 @@ hart_schema:
                   default: Read-only bit that summarizes whether either the FS field or
                     XS field signals the presence of some dirty state.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 63, allowed: [63]}
                 lsb: {type: integer, default: 63, allowed: [63]}
                 implemented: {type: boolean, default: true}
@@ -1189,6 +1235,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -1208,6 +1255,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -1239,6 +1287,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -1258,6 +1307,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -1289,6 +1339,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -1308,6 +1359,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -1340,6 +1392,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -1357,6 +1410,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -1393,6 +1447,7 @@ hart_schema:
                   type: string
                   default: Vector base address.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 31, allowed: [31]}
                 lsb: {type: integer, default: 2, allowed: [2]}
                 implemented: {type: boolean, default: true, allowed: [true]}
@@ -1412,6 +1467,7 @@ hart_schema:
                   type: string
                   default: Vector mode.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 1, allowed: [1]}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 implemented: {type: boolean, default: true, allowed: [true]}
@@ -1441,6 +1497,7 @@ hart_schema:
                   type: string
                   default: Vector base address.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 63, allowed: [63]}
                 lsb: {type: integer, default: 2, allowed: [2]}
                 implemented: {type: boolean, default: true, allowed: [true]}
@@ -1460,6 +1517,7 @@ hart_schema:
                   type: string
                   default: Vector mode.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 1, allowed: [1]}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 implemented: {type: boolean, default: true, allowed: [true]}
@@ -1496,6 +1554,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -1521,6 +1580,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -1561,6 +1621,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -1586,6 +1647,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -1630,6 +1692,7 @@ hart_schema:
                   type: string
                   default: User Software Interrupt Pending.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 0, allowed: [0]}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 implemented: {type: boolean, default: true}
@@ -1651,6 +1714,7 @@ hart_schema:
                   type: string
                   default: Supervisor Software Interrupt Pending.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 1, allowed: [1]}
                 lsb: {type: integer, default: 1, allowed: [1]}
                 implemented: {type: boolean, default: true}
@@ -1671,6 +1735,7 @@ hart_schema:
                   type: string
                   default: Machine Software Interrupt Pending.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 3, allowed: [3]}
                 lsb: {type: integer, default: 3, allowed: [3]}
                 implemented: {type: boolean, default: true}
@@ -1688,6 +1753,7 @@ hart_schema:
                   type: string
                   default: User Timer Interrupt Pending.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 4, allowed: [4]}
                 lsb: {type: integer, default: 4, allowed: [4]}
                 implemented: {type: boolean, default: true}
@@ -1709,6 +1775,7 @@ hart_schema:
                   type: string
                   default: Supervisor Timer Interrupt Pending.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 5, allowed: [5]}
                 lsb: {type: integer, default: 5, allowed: [5]}
                 implemented: {type: boolean, default: true}
@@ -1729,6 +1796,7 @@ hart_schema:
                   type: string
                   default: Machine Timer Interrupt Pending.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 7, allowed: [7]}
                 lsb: {type: integer, default: 7, allowed: [7]}
                 implemented: {type: boolean, default: true}
@@ -1746,6 +1814,7 @@ hart_schema:
                   type: string
                   default: User External Interrupt Pending.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 8, allowed: [8]}
                 lsb: {type: integer, default: 8, allowed: [8]}
                 implemented: {type: boolean, default: true}
@@ -1767,6 +1836,7 @@ hart_schema:
                   type: string
                   default: Supervisor External Interrupt Pending.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 9, allowed: [9]}
                 lsb: {type: integer, default: 9, allowed: [9]}
                 implemented: {type: boolean, default: true}
@@ -1787,6 +1857,7 @@ hart_schema:
                   type: string
                   default: Machine External Interrupt Pending.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 11, allowed: [11]}
                 lsb: {type: integer, default: 11, allowed: [11]}
                 implemented: {type: boolean, default: true}
@@ -1812,6 +1883,7 @@ hart_schema:
                   type: string
                   default: User Software Interrupt Pending.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 0, allowed: [0]}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 implemented: {type: boolean, default: true}
@@ -1833,6 +1905,7 @@ hart_schema:
                   type: string
                   default: Supervisor Software Interrupt Pending.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 1, allowed: [1]}
                 lsb: {type: integer, default: 1, allowed: [1]}
                 implemented: {type: boolean, default: true}
@@ -1853,6 +1926,7 @@ hart_schema:
                   type: string
                   default: Machine Software Interrupt Pending.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 3, allowed: [3]}
                 lsb: {type: integer, default: 3, allowed: [3]}
                 implemented: {type: boolean, default: true}
@@ -1870,6 +1944,7 @@ hart_schema:
                   type: string
                   default: User Timer Interrupt Pending.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 4, allowed: [4]}
                 lsb: {type: integer, default: 4, allowed: [4]}
                 implemented: {type: boolean, default: true}
@@ -1891,6 +1966,7 @@ hart_schema:
                   type: string
                   default: Supervisor Timer Interrupt Pending.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 5, allowed: [5]}
                 lsb: {type: integer, default: 5, allowed: [5]}
                 implemented: {type: boolean, default: true}
@@ -1911,6 +1987,7 @@ hart_schema:
                   type: string
                   default: Machine Timer Interrupt Pending.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 7, allowed: [7]}
                 lsb: {type: integer, default: 7, allowed: [7]}
                 implemented: {type: boolean, default: true}
@@ -1928,6 +2005,7 @@ hart_schema:
                   type: string
                   default: User External Interrupt Pending.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 8, allowed: [8]}
                 lsb: {type: integer, default: 8, allowed: [8]}
                 implemented: {type: boolean, default: true}
@@ -1949,6 +2027,7 @@ hart_schema:
                   type: string
                   default: Supervisor External Interrupt Pending.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 9, allowed: [9]}
                 lsb: {type: integer, default: 9, allowed: [9]}
                 implemented: {type: boolean, default: true}
@@ -1969,6 +2048,7 @@ hart_schema:
                   type: string
                   default: Machine External Interrupt Pending.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 11, allowed: [11]}
                 lsb: {type: integer, default: 11, allowed: [11]}
                 implemented: {type: boolean, default: true}
@@ -2008,6 +2088,7 @@ hart_schema:
                   type: string
                   default: User Software Interrupt enable.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 0, allowed: [0]}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 implemented: {type: boolean, default: true}
@@ -2029,6 +2110,7 @@ hart_schema:
                   type: string
                   default: Supervisor Software Interrupt enable.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 1, allowed: [1]}
                 lsb: {type: integer, default: 1, allowed: [1]}
                 implemented: {type: boolean, default: true}
@@ -2049,6 +2131,7 @@ hart_schema:
                   type: string
                   default: Machine Software Interrupt enable.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 3, allowed: [3]}
                 lsb: {type: integer, default: 3, allowed: [3]}
                 implemented: {type: boolean, default: true}
@@ -2069,6 +2152,7 @@ hart_schema:
                   type: string
                   default: User Timer Interrupt enable.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 4, allowed: [4]}
                 lsb: {type: integer, default: 4, allowed: [4]}
                 implemented: {type: boolean, default: true}
@@ -2090,6 +2174,7 @@ hart_schema:
                   type: string
                   default: Supervisor Timer Interrupt enable.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 5, allowed: [5]}
                 lsb: {type: integer, default: 5, allowed: [5]}
                 implemented: {type: boolean, default: true}
@@ -2110,6 +2195,7 @@ hart_schema:
                   type: string
                   default: Machine Timer Interrupt enable.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 7, allowed: [7]}
                 lsb: {type: integer, default: 7, allowed: [7]}
                 implemented: {type: boolean, default: true}
@@ -2129,6 +2215,7 @@ hart_schema:
                   type: string
                   default: User External Interrupt enable.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 8, allowed: [8]}
                 lsb: {type: integer, default: 8, allowed: [8]}
                 implemented: {type: boolean, default: true}
@@ -2150,6 +2237,7 @@ hart_schema:
                   type: string
                   default: Supervisor External Interrupt enable.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 9, allowed: [9]}
                 lsb: {type: integer, default: 9, allowed: [9]}
                 implemented: {type: boolean, default: true}
@@ -2170,6 +2258,7 @@ hart_schema:
                   type: string
                   default: Machine External Interrupt enable.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 11, allowed: [11]}
                 lsb: {type: integer, default: 11, allowed: [11]}
                 implemented: {type: boolean, default: true}
@@ -2196,6 +2285,7 @@ hart_schema:
                   type: string
                   default: User Software Interrupt enable.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 0, allowed: [0]}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 implemented: {type: boolean, default: true}
@@ -2217,6 +2307,7 @@ hart_schema:
                   type: string
                   default: Supervisor Software Interrupt enable.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 1, allowed: [1]}
                 lsb: {type: integer, default: 1, allowed: [1]}
                 implemented: {type: boolean, default: true}
@@ -2237,6 +2328,7 @@ hart_schema:
                   type: string
                   default: Machine Software Interrupt enable.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 3, allowed: [3]}
                 lsb: {type: integer, default: 3, allowed: [3]}
                 implemented: {type: boolean, default: true}
@@ -2257,6 +2349,7 @@ hart_schema:
                   type: string
                   default: User Timer Interrupt enable.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 4, allowed: [4]}
                 lsb: {type: integer, default: 4, allowed: [4]}
                 implemented: {type: boolean, default: true}
@@ -2278,6 +2371,7 @@ hart_schema:
                   type: string
                   default: Supervisor Timer Interrupt enable.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 5, allowed: [5]}
                 lsb: {type: integer, default: 5, allowed: [5]}
                 implemented: {type: boolean, default: true}
@@ -2298,6 +2392,7 @@ hart_schema:
                   type: string
                   default: Machine Timer Interrupt enable.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 7, allowed: [7]}
                 lsb: {type: integer, default: 7, allowed: [7]}
                 implemented: {type: boolean, default: true}
@@ -2317,6 +2412,7 @@ hart_schema:
                   type: string
                   default: User External Interrupt enable.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 8, allowed: [8]}
                 lsb: {type: integer, default: 8, allowed: [8]}
                 implemented: {type: boolean, default: true}
@@ -2338,6 +2434,7 @@ hart_schema:
                   type: string
                   default: Supervisor External Interrupt enable.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 9, allowed: [9]}
                 lsb: {type: integer, default: 9, allowed: [9]}
                 implemented: {type: boolean, default: true}
@@ -2358,6 +2455,7 @@ hart_schema:
                   type: string
                   default: Machine External Interrupt enable.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 11, allowed: [11]}
                 lsb: {type: integer, default: 11, allowed: [11]}
                 implemented: {type: boolean, default: true}
@@ -2390,6 +2488,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -2416,6 +2515,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -2455,6 +2555,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -2479,6 +2580,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -2516,6 +2618,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -2540,6 +2643,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -2581,6 +2685,7 @@ hart_schema:
                   type: string
                   default: Indicates whether the trap was due to an interrupt.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 31, allowed: [31]}
                 lsb: {type: integer, default: 31, allowed: [31]}
                 implemented: {type: boolean, default: true, allowed: [true]}
@@ -2599,6 +2704,7 @@ hart_schema:
                   type: string
                   default: Encodes the exception code.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 30, allowed: [30]}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 implemented: {type: boolean, default: true, allowed: [true]}
@@ -2625,6 +2731,7 @@ hart_schema:
                   type: string
                   default: Indicates whether the trap was due to an interrupt.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 63, allowed: [63]}
                 lsb: {type: integer, default: 63, allowed: [63]}
                 implemented: {type: boolean, default: true, allowed: [true]}
@@ -2642,6 +2749,7 @@ hart_schema:
                   type: string
                   default: Encodes the exception code.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 62, allowed: [62]}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 implemented: {type: boolean, default: true, allowed: [true]}
@@ -2675,6 +2783,7 @@ hart_schema:
               schema:
                 description: {type: string, default: pmp configuration bits}
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 7, allowed: [7]}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 implemented: {type: boolean, default: false}
@@ -2692,6 +2801,7 @@ hart_schema:
               schema:
                 description: {type: string, default: pmp configuration bits}
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 15, allowed: [15]}
                 lsb: {type: integer, default: 8, allowed: [8]}
                 implemented: {type: boolean, default: false}
@@ -2709,6 +2819,7 @@ hart_schema:
               schema:
                 description: {type: string, default: pmp configuration bits}
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 23, allowed: [23]}
                 lsb: {type: integer, default: 16, allowed: [16]}
                 implemented: {type: boolean, default: false}
@@ -2726,6 +2837,7 @@ hart_schema:
               schema:
                 description: {type: string, default: pmp configuration bits}
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 31, allowed: [31]}
                 lsb: {type: integer, default: 24, allowed: [24]}
                 implemented: {type: boolean, default: false}
@@ -2757,6 +2869,7 @@ hart_schema:
               schema:
                 description: {type: string, default: pmp configuration bits}
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 39, allowed: [39]}
                 lsb: {type: integer, default: 32, allowed: [32]}
                 implemented: {type: boolean, default: false}
@@ -2774,6 +2887,7 @@ hart_schema:
               schema:
                 description: {type: string, default: pmp configuration bits}
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 47, allowed: [47]}
                 lsb: {type: integer, default: 40, allowed: [40]}
                 implemented: {type: boolean, default: false}
@@ -2791,6 +2905,7 @@ hart_schema:
               schema:
                 description: {type: string, default: pmp configuration bits}
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 55, allowed: [55]}
                 lsb: {type: integer, default: 48, allowed: [48]}
                 implemented: {type: boolean, default: false}
@@ -2808,6 +2923,7 @@ hart_schema:
               schema:
                 description: {type: string, default: pmp configuration bits}
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 63, allowed: [63]}
                 lsb: {type: integer, default: 56, allowed: [56]}
                 implemented: {type: boolean, default: false}
@@ -3868,6 +3984,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -3892,6 +4009,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -3924,6 +4042,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -3940,6 +4059,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -4701,6 +4821,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -4719,6 +4840,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 2, allowed: [2]}
             type:
@@ -4750,6 +4872,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -4768,6 +4891,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 2, allowed: [2]}
             type:
@@ -4802,6 +4926,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 4, allowed: [4]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -4822,6 +4947,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 4, allowed: [4]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -4854,6 +4980,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 2, allowed: [2]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -4875,6 +5002,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 2, allowed: [2]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -4907,6 +5035,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 7, allowed: [7]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -4927,6 +5056,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 7, allowed: [7]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -4953,6 +5083,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: mcycle, nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [rv32_check]} 
@@ -4963,6 +5094,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: mcycle, nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {default: true, check_with: [rv64_check]} 
@@ -4982,6 +5114,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: mcycleh, nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean,  default: true,  check_with: [rv32_check]}
@@ -5003,6 +5136,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -5017,6 +5151,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -5040,6 +5175,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -5065,6 +5201,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: minstret, nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [rv32_check] }
@@ -5075,6 +5212,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: minstret, nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {default: true, check_with: [rv64_check]} 
@@ -5094,6 +5232,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: minstreth, nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean,  default: true,  check_with: [rv32_check]}
@@ -5113,6 +5252,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter3, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv32_check]}
@@ -5123,6 +5263,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter3, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv64_check]}
@@ -5140,6 +5281,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter4, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv32_check]} 
@@ -5150,6 +5292,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter4, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv64_check] }
@@ -5167,6 +5310,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter5, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv32_check] }
@@ -5177,6 +5321,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter5, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv64_check] }
@@ -5194,6 +5339,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter6, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv32_check]}
@@ -5204,6 +5350,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter6, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv64_check]}
@@ -5221,6 +5368,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter7, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv32_check]}
@@ -5231,6 +5379,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter7, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv64_check]}
@@ -5248,6 +5397,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter8, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv32_check]}
@@ -5258,6 +5408,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter8, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv64_check]}
@@ -5275,6 +5426,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter9, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv32_check]}
@@ -5285,6 +5437,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter9, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv64_check]}
@@ -5302,6 +5455,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter10, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv32_check]}
@@ -5312,6 +5466,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter10, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv64_check]}
@@ -5329,6 +5484,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter11, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv32_check]}
@@ -5339,6 +5495,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter11, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv64_check]}
@@ -5356,6 +5513,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter12, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv32_check]}
@@ -5366,6 +5524,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter12, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv64_check]}
@@ -5383,6 +5542,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter13, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv32_check]}
@@ -5393,6 +5553,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter13, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv64_check]}
@@ -5410,6 +5571,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter14, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv32_check]}
@@ -5420,6 +5582,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter14, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv64_check]}
@@ -5437,6 +5600,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter15, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv32_check]}
@@ -5447,6 +5611,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter15, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv64_check]}
@@ -5464,6 +5629,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter16, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv32_check]}
@@ -5474,6 +5640,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter16, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv64_check]}
@@ -5491,6 +5658,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter17, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv32_check]}
@@ -5518,6 +5686,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter18, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv32_check]}
@@ -5528,6 +5697,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter18, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv64_check]}
@@ -5545,6 +5715,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter19, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv32_check]}
@@ -5555,6 +5726,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter19, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv64_check]}
@@ -5572,6 +5744,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter20, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv32_check]}
@@ -5582,6 +5755,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter20, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv64_check]}
@@ -5599,6 +5773,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter21, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv32_check]}
@@ -5609,6 +5784,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter21, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv64_check]}
@@ -5626,6 +5802,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter22, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv32_check]}
@@ -5636,6 +5813,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter22, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv64_check]}
@@ -5653,6 +5831,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter23, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv32_check]}
@@ -5663,6 +5842,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter23, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv64_check]}
@@ -5680,6 +5860,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter24, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv32_check]}
@@ -5690,6 +5871,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter24, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv64_check]}
@@ -5707,6 +5889,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter25, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv32_check]}
@@ -5717,6 +5900,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter25, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv64_check]}
@@ -5734,6 +5918,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter26, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv32_check]}
@@ -5744,6 +5929,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter26, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv64_check]}
@@ -5761,6 +5947,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter27, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv32_check]}
@@ -5771,6 +5958,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter27, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv64_check]}
@@ -5788,6 +5976,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter28, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv32_check]}
@@ -5798,6 +5987,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter28, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv64_check]}
@@ -5815,6 +6005,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter29, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv32_check]}
@@ -5825,6 +6016,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter29, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv64_check]}
@@ -5842,6 +6034,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter30, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv32_check]}
@@ -5852,6 +6045,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter30, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv64_check]}
@@ -5869,6 +6063,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter31, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv32_check]}
@@ -5879,6 +6074,7 @@ hart_schema:
           schema: 
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter31, nullable: False}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: {type: boolean, default: true, check_with: [ rv64_check]}
@@ -5896,6 +6092,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter3h, nullable: false}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: { type: boolean, default: true, check_with: [rv32_check]}
@@ -5918,6 +6115,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter4h, nullable: false}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: { type: boolean, default: true, check_with: [rv32_check]}
@@ -5940,6 +6138,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter5h, nullable: false}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: { type: boolean, default: true, check_with: [rv32_check]}
@@ -5962,6 +6161,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter6h, nullable: false}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: { type: boolean, default: true, check_with: [rv32_check]}
@@ -5984,6 +6184,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter7h, nullable: false}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: { type: boolean, default: true, check_with: [rv32_check]}
@@ -6006,6 +6207,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter8h, nullable: false}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: { type: boolean, default: true, check_with: [rv32_check]}
@@ -6028,6 +6230,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter9h, nullable: false}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: { type: boolean, default: true, check_with: [rv32_check]}
@@ -6050,6 +6253,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter10h, nullable: false}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: { type: boolean, default: true, check_with: [rv32_check]}
@@ -6072,6 +6276,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter11h, nullable: false}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: { type: boolean, default: true, check_with: [rv32_check]}
@@ -6094,6 +6299,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter12h, nullable: false}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: { type: boolean, default: true, check_with: [rv32_check]}
@@ -6116,6 +6322,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter13h, nullable: false}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: { type: boolean, default: true, check_with: [rv32_check]}
@@ -6138,6 +6345,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter14h, nullable: false}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: { type: boolean, default: true, check_with: [rv32_check]}
@@ -6160,6 +6368,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter15h, nullable: false}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: { type: boolean, default: true, check_with: [rv32_check]}
@@ -6182,6 +6391,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter16h, nullable: false}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: { type: boolean, default: true, check_with: [rv32_check]}
@@ -6204,6 +6414,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter17h, nullable: false}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: { type: boolean, default: true, check_with: [rv32_check]}
@@ -6226,6 +6437,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter18h, nullable: false}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: { type: boolean, default: true, check_with: [rv32_check]}
@@ -6248,6 +6460,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter19h, nullable: false}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: { type: boolean, default: true, check_with: [rv32_check]}
@@ -6270,6 +6483,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter20h, nullable: false}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: { type: boolean, default: true, check_with: [rv32_check]}
@@ -6292,6 +6506,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter21h, nullable: false}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: { type: boolean, default: true, check_with: [rv32_check]}
@@ -6314,6 +6529,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter22h, nullable: false}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: { type: boolean, default: true, check_with: [rv32_check]}
@@ -6336,6 +6552,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter23h, nullable: false}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: { type: boolean, default: true, check_with: [rv32_check]}
@@ -6358,6 +6575,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter24h, nullable: false}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: { type: boolean, default: true, check_with: [rv32_check]}
@@ -6380,6 +6598,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter25h, nullable: false}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: { type: boolean, default: true, check_with: [rv32_check]}
@@ -6402,6 +6621,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter26h, nullable: false}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: { type: boolean, default: true, check_with: [rv32_check]}
@@ -6424,6 +6644,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter27h, nullable: false}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: { type: boolean, default: true, check_with: [rv32_check]}
@@ -6446,6 +6667,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter28h, nullable: false}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: { type: boolean, default: true, check_with: [rv32_check]}
@@ -6468,6 +6690,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter29h, nullable: false}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: { type: boolean, default: true, check_with: [rv32_check]}
@@ -6490,6 +6713,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter30h, nullable: false}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: { type: boolean, default: true, check_with: [rv32_check]}
@@ -6512,6 +6736,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: mhpmcounter31h, nullable: false}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             accessible: { type: boolean, default: true, check_with: [rv32_check]}
@@ -6546,6 +6771,7 @@ hart_schema:
               schema:
                 description: {type: string,  default: Stores the state of the user mode interrupts.}
                 shadow: {type: string, default: mstatus.uie, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 0, allowed: [0]}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 implemented: {type: boolean, default: true}
@@ -6556,6 +6782,7 @@ hart_schema:
               schema:
                 description: { type: string, default: Stores the state of the supervisor mode interrupts.}
                 shadow: {type: string, default: mstatus.sie, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 1, allowed: [1]}
                 lsb: {type: integer, default: 1, allowed: [1]}
                 implemented: {type: boolean, default: true}
@@ -6568,6 +6795,7 @@ hart_schema:
                   type: string
                   default: Stores the state of the user mode interrupts prior to the trap.
                 shadow: {type: string, default: mstatus.upie, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 4, allowed: [4]}
                 lsb: {type: integer, default: 4, allowed: [4]}
                 implemented: {type: boolean, default: true}
@@ -6581,6 +6809,7 @@ hart_schema:
                   default: Stores the state of the supervisor mode interrupts prior to
                     the trap.
                 shadow: {type: string, default: mstatus.spie, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 5, allowed: [5]}
                 lsb: {type: integer, default: 5, allowed: [5]}
                 implemented: {type: boolean, default: true}
@@ -6593,6 +6822,7 @@ hart_schema:
                   type: string
                   default: Stores the previous priority mode for supervisor.
                 shadow: {type: string, default: mstatus.spp, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 8, allowed: [8]}
                 lsb: {type: integer, default: 8, allowed: [8]}
                 implemented: {type: boolean, default: true}
@@ -6606,6 +6836,7 @@ hart_schema:
                   default: Encodes the status of the floating-point unit, including the
                     CSR fcsr and floating-point data registers.
                 shadow: {type: string, default: mstatus.fs, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 14, allowed: [14]}
                 lsb: {type: integer, default: 13, allowed: [13]}
                 implemented: {type: boolean, default: true}
@@ -6618,6 +6849,7 @@ hart_schema:
                   default: Encodes the status of additional user-mode extensions and associated
                     state.
                 shadow: {type: string, default: mstatus.xs, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 16, allowed: [16]}
                 lsb: {type: integer, default: 15, allowed: [15]}
                 implemented: {type: boolean, default: true}
@@ -6630,6 +6862,7 @@ hart_schema:
                   default: Modifies the privilege with which S-mode loads and stores access
                     virtual memory.
                 shadow: {type: string, default: mstatus.sum, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 18, allowed: [18]}
                 lsb: {type: integer, default: 18, allowed: [18]}
                 implemented: {type: boolean, default: true}
@@ -6642,6 +6875,7 @@ hart_schema:
                   type: string
                   default: Modifies the privilege with which loads access virtual memory.
                 shadow: {type: string, default: mstatus.mxr, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 19, allowed: [19]}
                 lsb: {type: integer, default: 19, allowed: [19]}
                 implemented: {type: boolean, default: true}
@@ -6655,6 +6889,7 @@ hart_schema:
                   default: Read-only bit that summarizes whether either the FS field or
                     XS field signals the presence of some dirty state.
                 shadow: {type: string, default: mstatus.sd, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 31, allowed: [31]}
                 lsb: {type: integer, default: 31, allowed: [31]}
                 implemented: {type: boolean, default: true}
@@ -6673,6 +6908,7 @@ hart_schema:
               schema:
                 description: {type: string,  default: Stores the state of the user mode interrupts.}
                 shadow: {type: string, default: mstatus.uie, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 0, allowed: [0]}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 implemented: {type: boolean, default: true}
@@ -6683,6 +6919,7 @@ hart_schema:
               schema:
                 description: { type: string, default: Stores the state of the supervisor mode interrupts.}
                 shadow: {type: string, default: mstatus.sie, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 1, allowed: [1]}
                 lsb: {type: integer, default: 1, allowed: [1]}
                 implemented: {type: boolean, default: true}
@@ -6695,6 +6932,7 @@ hart_schema:
                   type: string
                   default: Stores the state of the user mode interrupts prior to the trap.
                 shadow: {type: string, default: mstatus.upie, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 4, allowed: [4]}
                 lsb: {type: integer, default: 4, allowed: [4]}
                 implemented: {type: boolean, default: true}
@@ -6708,6 +6946,7 @@ hart_schema:
                   default: Stores the state of the supervisor mode interrupts prior to
                     the trap.
                 shadow: {type: string, default: mstatus.spie, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 5, allowed: [5]}
                 lsb: {type: integer, default: 5, allowed: [5]}
                 implemented: {type: boolean, default: true}
@@ -6720,6 +6959,7 @@ hart_schema:
                   type: string
                   default: Stores the previous priority mode for supervisor.
                 shadow: {type: string, default: mstatus.spp, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 8, allowed: [8]}
                 lsb: {type: integer, default: 8, allowed: [8]}
                 implemented: {type: boolean, default: true}
@@ -6733,6 +6973,7 @@ hart_schema:
                   default: Encodes the status of the floating-point unit, including the
                     CSR fcsr and floating-point data registers.
                 shadow: {type: string, default: mstatus.fs, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 14, allowed: [14]}
                 lsb: {type: integer, default: 13, allowed: [13]}
                 implemented: {type: boolean, default: true}
@@ -6745,6 +6986,7 @@ hart_schema:
                   default: Encodes the status of additional user-mode extensions and associated
                     state.
                 shadow: {type: string, default: mstatus.xs, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 16, allowed: [16]}
                 lsb: {type: integer, default: 15, allowed: [15]}
                 implemented: {type: boolean, default: true}
@@ -6757,6 +6999,7 @@ hart_schema:
                   default: Modifies the privilege with which S-mode loads and stores access
                     virtual memory.
                 shadow: {type: string, default: mstatus.sum, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 18, allowed: [18]}
                 lsb: {type: integer, default: 18, allowed: [18]}
                 implemented: {type: boolean, default: true}
@@ -6769,6 +7012,7 @@ hart_schema:
                   type: string
                   default: Modifies the privilege with which loads access virtual memory.
                 shadow: {type: string, default: mstatus.mxr, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 19, allowed: [19]}
                 lsb: {type: integer, default: 19, allowed: [19]}
                 implemented: {type: boolean, default: true}
@@ -6779,6 +7023,7 @@ hart_schema:
               schema:
                 description: {type: string, default: Controls the xlen for User mode.}
                 shadow: {type: string, default: mstatus.uxl, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 33, allowed: [33]}
                 lsb: {type: integer, default: 32, allowed: [32]}
                 implemented: {type: boolean, default: true}
@@ -6792,6 +7037,7 @@ hart_schema:
                   default: Read-only bit that summarizes whether either the FS field or
                     XS field signals the presence of some dirty state.
                 shadow: {type: string, default: mstatus.sd, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 63, allowed: [63]}
                 lsb: {type: integer, default: 63, allowed: [63]}
                 implemented: {type: boolean, default: true}
@@ -6824,6 +7070,7 @@ hart_schema:
               schema:
                 description: {type: string, default: User Software Interrupt enable.}
                 shadow: {type: string, default: mie.usie, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 0, allowed: [0]}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 implemented: {type: boolean, default: true}
@@ -6833,6 +7080,7 @@ hart_schema:
               schema:
                 description: {type: string, default: Supervisor Software Interrupt enable.}
                 shadow: {type: string, default: mie.ssie, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 1, allowed: [1]}
                 lsb: {type: integer, default: 1, allowed: [1]}
                 implemented: {type: boolean, default: true}
@@ -6842,6 +7090,7 @@ hart_schema:
               schema:
                 description: { type: string, default: User Timer Interrupt enable.}
                 shadow: {type: string, default: mie.utie, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 4, allowed: [4]}
                 lsb: {type: integer, default: 4, allowed: [4]}
                 implemented: {type: boolean, default: true}
@@ -6851,6 +7100,7 @@ hart_schema:
               schema:
                 description: { type: string, default: Supervisor Timer Interrupt enable.}
                 shadow: {type: string, default: mie.stie , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 5, allowed: [5]}
                 lsb: {type: integer, default: 5, allowed: [5]}
                 implemented: {type: boolean, default: true}
@@ -6860,6 +7110,7 @@ hart_schema:
               schema:
                 description: { type: string, default: User External Interrupt enable.}
                 shadow: {type: string, default: mie.ueie, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 8, allowed: [8]}
                 lsb: {type: integer, default: 8, allowed: [8]}
                 implemented: {type: boolean, default: true}
@@ -6869,6 +7120,7 @@ hart_schema:
               schema:
                 description: { type: string, default: Supervisor External Interrupt enable.}
                 shadow: {type: string, default: mie.seie, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 9, allowed: [9]}
                 lsb: {type: integer, default: 9, allowed: [9]}
                 implemented: {type: boolean, default: true}
@@ -6887,6 +7139,7 @@ hart_schema:
               schema:
                 description: {type: string, default: User Software Interrupt enable.}
                 shadow: {type: string, default: mie.usie, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 0, allowed: [0]}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 implemented: {type: boolean, default: true}
@@ -6896,6 +7149,7 @@ hart_schema:
               schema:
                 description: {type: string, default: Supervisor Software Interrupt enable.}
                 shadow: {type: string, default: mie.ssie, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 1, allowed: [1]}
                 lsb: {type: integer, default: 1, allowed: [1]}
                 implemented: {type: boolean, default: true}
@@ -6905,6 +7159,7 @@ hart_schema:
               schema:
                 description: { type: string, default: User Timer Interrupt enable.}
                 shadow: {type: string, default: mie.utie, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 4, allowed: [4]}
                 lsb: {type: integer, default: 4, allowed: [4]}
                 implemented: {type: boolean, default: true}
@@ -6914,6 +7169,7 @@ hart_schema:
               schema:
                 description: { type: string, default: Supervisor Timer Interrupt enable.}
                 shadow: {type: string, default: mie.stie , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 5, allowed: [5]}
                 lsb: {type: integer, default: 5, allowed: [5]}
                 implemented: {type: boolean, default: true}
@@ -6923,6 +7179,7 @@ hart_schema:
               schema:
                 description: { type: string, default: User External Interrupt enable.}
                 shadow: {type: string, default: mie.ueie, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 8, allowed: [8]}
                 lsb: {type: integer, default: 8, allowed: [8]}
                 implemented: {type: boolean, default: true}
@@ -6932,6 +7189,7 @@ hart_schema:
               schema:
                 description: { type: string, default: Supervisor External Interrupt enable.}
                 shadow: {type: string, default: mie.seie, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 9, allowed: [9]}
                 lsb: {type: integer, default: 9, allowed: [9]}
                 implemented: {type: boolean, default: False}
@@ -6963,6 +7221,7 @@ hart_schema:
               schema:
                 description: {type: string, default: User Software Interrupt enable.}
                 shadow: {type: string, default: mip.usip, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 0, allowed: [0]}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 implemented: {type: boolean, default: true}
@@ -6972,6 +7231,7 @@ hart_schema:
               schema:
                 description: {type: string, default: Supervisor Software Interrupt enable.}
                 shadow: {type: string, default: mip.ssip, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 1, allowed: [1]}
                 lsb: {type: integer, default: 1, allowed: [1]}
                 implemented: {type: boolean, default: true}
@@ -6981,6 +7241,7 @@ hart_schema:
               schema:
                 description: { type: string, default: User Timer Interrupt enable.}
                 shadow: {type: string, default: mip.utip, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 4, allowed: [4]}
                 lsb: {type: integer, default: 4, allowed: [4]}
                 implemented: {type: boolean, default: true}
@@ -6990,6 +7251,7 @@ hart_schema:
               schema:
                 description: { type: string, default: Supervisor Timer Interrupt enable.}
                 shadow: {type: string, default: mip.stip , nullable: True}
+                shadow_type: {type: string, default: ro, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 5, allowed: [5]}
                 lsb: {type: integer, default: 5, allowed: [5]}
                 implemented: {type: boolean, default: true}
@@ -6999,6 +7261,7 @@ hart_schema:
               schema:
                 description: { type: string, default: User External Interrupt enable.}
                 shadow: {type: string, default: mip.ueip, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 8, allowed: [8]}
                 lsb: {type: integer, default: 8, allowed: [8]}
                 implemented: {type: boolean, default: true}
@@ -7008,6 +7271,7 @@ hart_schema:
               schema:
                 description: { type: string, default: Supervisor External Interrupt enable.}
                 shadow: {type: string, default: mip.seip, nullable: True}
+                shadow_type: {type: string, default: ro, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 9, allowed: [9]}
                 lsb: {type: integer, default: 9, allowed: [9]}
                 implemented: {type: boolean, default: true}
@@ -7026,6 +7290,7 @@ hart_schema:
               schema:
                 description: {type: string, default: User Software Interrupt enable.}
                 shadow: {type: string, default: mip.usip, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 0, allowed: [0]}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 implemented: {type: boolean, default: true}
@@ -7035,6 +7300,7 @@ hart_schema:
               schema:
                 description: {type: string, default: Supervisor Software Interrupt enable.}
                 shadow: {type: string, default: mip.ssip, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 1, allowed: [1]}
                 lsb: {type: integer, default: 1, allowed: [1]}
                 implemented: {type: boolean, default: true}
@@ -7044,6 +7310,7 @@ hart_schema:
               schema:
                 description: { type: string, default: User Timer Interrupt enable.}
                 shadow: {type: string, default: mip.utip, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 4, allowed: [4]}
                 lsb: {type: integer, default: 4, allowed: [4]}
                 implemented: {type: boolean, default: true}
@@ -7053,6 +7320,7 @@ hart_schema:
               schema:
                 description: { type: string, default: Supervisor Timer Interrupt enable.}
                 shadow: {type: string, default: mip.stip , nullable: True}
+                shadow_type: {type: string, default: ro, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 5, allowed: [5]}
                 lsb: {type: integer, default: 5, allowed: [5]}
                 implemented: {type: boolean, default: true}
@@ -7062,6 +7330,7 @@ hart_schema:
               schema:
                 description: { type: string, default: User External Interrupt enable.}
                 shadow: {type: string, default: mip.ueip, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 8, allowed: [8]}
                 lsb: {type: integer, default: 8, allowed: [8]}
                 implemented: {type: boolean, default: true}
@@ -7071,6 +7340,7 @@ hart_schema:
               schema:
                 description: { type: string, default: Supervisor External Interrupt enable.}
                 shadow: {type: string, default: mip.seip, nullable: True}
+                shadow_type: {type: string, default: ro, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 9, allowed: [9]}
                 lsb: {type: integer, default: 9, allowed: [9]}
                 implemented: {type: boolean, default: true}
@@ -7098,6 +7368,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -7125,6 +7396,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -7165,6 +7437,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -7190,6 +7463,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -7228,6 +7502,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -7253,6 +7528,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -7295,6 +7571,7 @@ hart_schema:
                   type: string
                   default: Indicates whether the trap was due to an interrupt.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 31, allowed: [31]}
                 lsb: {type: integer, default: 31, allowed: [31]}
                 implemented: {type: boolean, default: true}
@@ -7313,6 +7590,7 @@ hart_schema:
                   type: string
                   default: Encodes the exception code.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 30, allowed: [30]}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 implemented: {type: boolean, default: true}
@@ -7340,6 +7618,7 @@ hart_schema:
                   type: string
                   default: Indicates whether the trap was due to an interrupt.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 63, allowed: [63]}
                 lsb: {type: integer, default: 63, allowed: [63]}
                 implemented: {type: boolean, default: true}
@@ -7357,6 +7636,7 @@ hart_schema:
                   type: string
                   default: Encodes the exception code.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 62, allowed: [62]}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 implemented: {type: boolean, default: true}
@@ -7397,6 +7677,7 @@ hart_schema:
                   type: string
                   default: Vector base address.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 31, allowed: [31]}
                 lsb: {type: integer, default: 2, allowed: [2]}
                 implemented: {type: boolean, default: true}
@@ -7416,6 +7697,7 @@ hart_schema:
                   type: string
                   default: Vector mode.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 1, allowed: [1]}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 implemented: {type: boolean, default: true}
@@ -7445,6 +7727,7 @@ hart_schema:
                   type: string
                   default: Vector base address.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 63, allowed: [63]}
                 lsb: {type: integer, default: 2, allowed: [2]}
                 implemented: {type: boolean, default: true}
@@ -7464,6 +7747,7 @@ hart_schema:
                   type: string
                   default: Vector mode.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 1, allowed: [1]}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 implemented: {type: boolean, default: true}
@@ -7498,6 +7782,7 @@ hart_schema:
               schema:
                 description: { type: string , default: Physical Page Number }
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 21, allowed: [21]}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 implemented: {type: boolean, default: true}
@@ -7513,6 +7798,7 @@ hart_schema:
               schema:
                 description: { type: string, default: Address Space identifier. }
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 30, allowed: [30]}
                 lsb: {type: integer, default: 22, allowed: [22]}
                 implemented: {type: boolean, default: true}
@@ -7528,6 +7814,7 @@ hart_schema:
               schema:
                 description: { type: string, default: Vector mode. }
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 31, allowed: [31]}
                 lsb: {type: integer, default: 31, allowed: [31]}
                 implemented: {type: boolean, default: true}
@@ -7555,6 +7842,7 @@ hart_schema:
                   type: string
                   default: Physical Page Number
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 43, allowed: [43]}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 implemented: {type: boolean, default: true}
@@ -7572,6 +7860,7 @@ hart_schema:
                   type: string
                   default: Address Space identifier.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 59, allowed: [59]}
                 lsb: {type: integer, default: 44, allowed: [44]}
                 implemented: {type: boolean, default: true}
@@ -7589,6 +7878,7 @@ hart_schema:
                   type: string
                   default: Vector mode.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 63, allowed: [63]}
                 lsb: {type: integer, default: 60, allowed: [60]}
                 implemented: {type: boolean, default: true}
@@ -7626,6 +7916,7 @@ hart_schema:
               schema:
                 description: {type: string,  default: Stores the state of the user mode interrupts.}
                 shadow: {type: string, default: mstatus.uie, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 0, allowed: [0]}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 implemented: {type: boolean, default: true}
@@ -7638,6 +7929,7 @@ hart_schema:
                   type: string
                   default: Stores the state of the user mode interrupts prior to the trap.
                 shadow: {type: string, default: mstatus.upie, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 4, allowed: [4]}
                 lsb: {type: integer, default: 4, allowed: [4]}
                 implemented: {type: boolean, default: true}
@@ -7657,6 +7949,7 @@ hart_schema:
               schema:
                 description: {type: string,  default: Stores the state of the user mode interrupts.}
                 shadow: {type: string, default: mstatus.uie, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 0, allowed: [0]}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 implemented: {type: boolean, default: true}
@@ -7669,6 +7962,7 @@ hart_schema:
                   type: string
                   default: Stores the state of the user mode interrupts prior to the trap.
                 shadow: {type: string, default: mstatus.upie, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 4, allowed: [4]}
                 lsb: {type: integer, default: 4, allowed: [4]}
                 implemented: {type: boolean, default: true}
@@ -7702,6 +7996,7 @@ hart_schema:
               schema:
                 description: {type: string, default: User Software Interrupt enable.}
                 shadow: {type: string, default: mie.usie, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 0, allowed: [0]}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 implemented: {type: boolean, default: true}
@@ -7711,6 +8006,7 @@ hart_schema:
               schema:
                 description: { type: string, default: User Timer Interrupt enable.}
                 shadow: {type: string, default: mie.utie, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 4, allowed: [4]}
                 lsb: {type: integer, default: 4, allowed: [4]}
                 implemented: {type: boolean, default: true}
@@ -7720,6 +8016,7 @@ hart_schema:
               schema:
                 description: { type: string, default: User External Interrupt enable.}
                 shadow: {type: string, default: mie.ueie, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 8, allowed: [8]}
                 lsb: {type: integer, default: 8, allowed: [8]}
                 implemented: {type: boolean, default: true}
@@ -7738,6 +8035,7 @@ hart_schema:
               schema:
                 description: {type: string, default: User Software Interrupt enable.}
                 shadow: {type: string, default: mie.usie, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 0, allowed: [0]}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 implemented: {type: boolean, default: true}
@@ -7747,6 +8045,7 @@ hart_schema:
               schema:
                 description: { type: string, default: User Timer Interrupt enable.}
                 shadow: {type: string, default: mie.utie, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 4, allowed: [4]}
                 lsb: {type: integer, default: 4, allowed: [4]}
                 implemented: {type: boolean, default: true}
@@ -7756,6 +8055,7 @@ hart_schema:
               schema:
                 description: { type: string, default: User External Interrupt enable.}
                 shadow: {type: string, default: mie.ueie, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 8, allowed: [8]}
                 lsb: {type: integer, default: 8, allowed: [8]}
                 implemented: {type: boolean, default: true}
@@ -7787,6 +8087,7 @@ hart_schema:
               schema:
                 description: {type: string, default: User Software Interrupt enable.}
                 shadow: {type: string, default: mip.usip, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 0, allowed: [0]}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 implemented: {type: boolean, default: true}
@@ -7796,6 +8097,7 @@ hart_schema:
               schema:
                 description: { type: string, default: User Timer Interrupt enable.}
                 shadow: {type: string, default: mip.utip, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 4, allowed: [4]}
                 lsb: {type: integer, default: 4, allowed: [4]}
                 implemented: {type: boolean, default: true}
@@ -7805,6 +8107,7 @@ hart_schema:
               schema:
                 description: { type: string, default: User External Interrupt enable.}
                 shadow: {type: string, default: mip.ueip, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 8, allowed: [8]}
                 lsb: {type: integer, default: 8, allowed: [8]}
                 implemented: {type: boolean, default: true}
@@ -7823,6 +8126,7 @@ hart_schema:
               schema:
                 description: {type: string, default: User Software Interrupt enable.}
                 shadow: {type: string, default: mip.usip, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 0, allowed: [0]}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 implemented: {type: boolean, default: true}
@@ -7832,6 +8136,7 @@ hart_schema:
               schema:
                 description: { type: string, default: User Timer Interrupt enable.}
                 shadow: {type: string, default: mip.utip, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 4, allowed: [4]}
                 lsb: {type: integer, default: 4, allowed: [4]}
                 implemented: {type: boolean, default: true}
@@ -7841,6 +8146,7 @@ hart_schema:
               schema:
                 description: { type: string, default: User External Interrupt enable.}
                 shadow: {type: string, default: mip.ueip, nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 8, allowed: [8]}
                 lsb: {type: integer, default: 8, allowed: [8]}
                 implemented: {type: boolean, default: true}
@@ -7868,6 +8174,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -7895,6 +8202,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -7935,6 +8243,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -7960,6 +8269,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -7998,6 +8308,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -8023,6 +8334,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 63, allowed: [63]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -8065,6 +8377,7 @@ hart_schema:
                   type: string
                   default: Indicates whether the trap was due to an interrupt.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 31, allowed: [31]}
                 lsb: {type: integer, default: 31, allowed: [31]}
                 implemented: {type: boolean, default: true}
@@ -8083,6 +8396,7 @@ hart_schema:
                   type: string
                   default: Encodes the exception code.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 30, allowed: [30]}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 implemented: {type: boolean, default: true}
@@ -8110,6 +8424,7 @@ hart_schema:
                   type: string
                   default: Indicates whether the trap was due to an interrupt.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 63, allowed: [63]}
                 lsb: {type: integer, default: 63, allowed: [63]}
                 implemented: {type: boolean, default: true}
@@ -8127,6 +8442,7 @@ hart_schema:
                   type: string
                   default: Encodes the exception code.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 62, allowed: [62]}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 implemented: {type: boolean, default: true}
@@ -8167,6 +8483,7 @@ hart_schema:
                   type: string
                   default: Vector base address.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 31, allowed: [31]}
                 lsb: {type: integer, default: 2, allowed: [2]}
                 implemented: {type: boolean, default: true}
@@ -8186,6 +8503,7 @@ hart_schema:
                   type: string
                   default: Vector mode.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 1, allowed: [1]}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 implemented: {type: boolean, default: true}
@@ -8215,6 +8533,7 @@ hart_schema:
                   type: string
                   default: Vector base address.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 63, allowed: [63]}
                 lsb: {type: integer, default: 2, allowed: [2]}
                 implemented: {type: boolean, default: true}
@@ -8234,6 +8553,7 @@ hart_schema:
                   type: string
                   default: Vector mode.
                 shadow: {type: string, default: , nullable: True}
+                shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
                 msb: {type: integer, default: 1, allowed: [1]}
                 lsb: {type: integer, default: 0, allowed: [0]}
                 implemented: {type: boolean, default: true}
@@ -8268,6 +8588,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:
@@ -8292,6 +8613,7 @@ hart_schema:
           schema:
             fields: {type: list, default: []}
             shadow: {type: string, default: , nullable: True}
+            shadow_type: {type: string, default: rw, nullable: True, allowed: ['rw','ro']}
             msb: {type: integer, default: 31, allowed: [31]}
             lsb: {type: integer, default: 0, allowed: [0]}
             type:

--- a/riscv_config/schemas/schema_isa.yaml
+++ b/riscv_config/schemas/schema_isa.yaml
@@ -137,6 +137,7 @@ hart_schema:
       type: list
       schema: { type: integer, allowed: [ 32, 64, 128] }
       required: true
+      check_with: isa_xlen
       
     ###
     #pmp_granularity

--- a/riscv_config/schemas/schema_platform.yaml
+++ b/riscv_config/schemas/schema_platform.yaml
@@ -122,38 +122,6 @@ mtimecmp:
     implemented: False
 
 ###
-#mcause_non_standard
-#-------------------
-#
-# **Description**: Stores the fields for the *mcause* register.
-#
-#   * implemented: A boolean field indicating that the register has been implemented.
-#   * values: The list of exception values greater than 16 as assumed by the platform as integers.
-# 
-# **Examples**: 
-# 
-# .. code-block:: yaml
-#
-#   mcause_non_standard:
-#      implemented: True
-#      value: [16,17,20]
-#
-# **Constraints**:
-#
-#       - None
-
-mcause_non_standard:
-  type: dict
-  schema:
-    implemented:
-      type: boolean
-    values:
-      type: list
-      check_with: xcause_check
-  default:
-    implemented: True
-
-###
 #mtval_condition_writes
 #-----
 #


### PR DESCRIPTION
### Fixed
- fixed issue #58 by adding extra checks for bitmask
- fixed issue #59 by removing custom cause from platform yaml
- resolved inconsistencies in the use of "xlen" and "supported_xlen" in schemaValidator
### Added
- added extra "shadow_type" fields in the csr schemas. These indicate the nature of shadow
  (read-only, read-write, etc).
- added parking_loop node in debug_schema to indicate the address of debug rom. Can be empty in
  implementations which do not have this feature
